### PR TITLE
Make test paths xplat friendly

### DIFF
--- a/slnup.sln
+++ b/slnup.sln
@@ -29,7 +29,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualStudio.VersionScraper
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlnUp.Core", "src\SlnUp.Core\SlnUp.Core.csproj", "{2D0B8972-41BD-4530-9495-9DF5E60FB1CF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlnUp.Core.Tests", "src\SlnUp.Core.Tests\SlnUp.Core.Tests.csproj", "{F39C69B9-BAE2-499C-B9C4-864F4E5341ED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlnUp.Core.Tests", "src\SlnUp.Core.Tests\SlnUp.Core.Tests.csproj", "{F39C69B9-BAE2-499C-B9C4-864F4E5341ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlnUp.TestLibrary", "src\SlnUp.TestLibrary\SlnUp.TestLibrary.csproj", "{CB0DCF5C-167B-42AC-BF07-97FDAA739B27}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{F39C69B9-BAE2-499C-B9C4-864F4E5341ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F39C69B9-BAE2-499C-B9C4-864F4E5341ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F39C69B9-BAE2-499C-B9C4-864F4E5341ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB0DCF5C-167B-42AC-BF07-97FDAA739B27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB0DCF5C-167B-42AC-BF07-97FDAA739B27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB0DCF5C-167B-42AC-BF07-97FDAA739B27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB0DCF5C-167B-42AC-BF07-97FDAA739B27}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,6 +71,7 @@ Global
 		{55B7C584-3CCA-4E99-B2F0-DEB7B47148D6} = {E392EF9F-8A64-4B8D-AC44-6E760ED65348}
 		{7C64E9F4-5558-4C6E-95D8-8756185D0017} = {13BEBBDD-8976-428C-96C9-6CA1BDD70AC4}
 		{F39C69B9-BAE2-499C-B9C4-864F4E5341ED} = {E392EF9F-8A64-4B8D-AC44-6E760ED65348}
+		{CB0DCF5C-167B-42AC-BF07-97FDAA739B27} = {E392EF9F-8A64-4B8D-AC44-6E760ED65348}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {077C9799-D020-472A-A37B-BCDDD2AF3641}

--- a/src/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
+++ b/src/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SlnUp.Core\SlnUp.Core.csproj" />
+    <ProjectReference Include="..\SlnUp.TestLibrary\SlnUp.TestLibrary.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/SlnUp.Core.Tests/VisualStudioVersionTests.cs
+++ b/src/SlnUp.Core.Tests/VisualStudioVersionTests.cs
@@ -1,6 +1,7 @@
 namespace SlnUp.Core.Tests;
 
 using FluentAssertions;
+using SlnUp.TestLibrary;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
@@ -121,7 +122,7 @@ public class VisualStudioVersionTests
     public void FromJsonFile()
     {
         // Arrange
-        const string filePath = "C:/foo.json";
+        string filePath = "C:/foo.json".ToCrossPlatformPath();
         IFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
             [filePath] = new MockFileData(commonVersionsJson),
@@ -169,7 +170,7 @@ public class VisualStudioVersionTests
     {
         // Arrange
         MockFileSystem fileSystem = new();
-        const string filePath = "C:/foo.json";
+        string filePath = "C:/foo.json".ToCrossPlatformPath();
 
         // Act
         VisualStudioVersion.ToJsonFile(fileSystem, commonVersions, filePath);

--- a/src/SlnUp.TestLibrary/Extensions/StringExtensions.cs
+++ b/src/SlnUp.TestLibrary/Extensions/StringExtensions.cs
@@ -1,0 +1,25 @@
+namespace SlnUp.TestLibrary;
+
+using System.IO.Abstractions.TestingHelpers;
+
+/// <summary>
+/// Class StringExtensions.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Converts to a cross-platform path from a Windows path.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns><see cref="string"/>.</returns>
+    public static string ToCrossPlatformPath(this string path)
+        => MockUnixSupport.Path(path);
+
+    /// <summary>
+    /// Converts to cross-platform paths from Windows paths.
+    /// </summary>
+    /// <param name="paths">The paths.</param>
+    /// <returns><see cref="string"/>.</returns>
+    public static IEnumerable<string> ToCrossPlatformPath(this IEnumerable<string> paths)
+        => paths.Select(MockUnixSupport.Path);
+}

--- a/src/SlnUp.TestLibrary/SlnUp.TestLibrary.csproj
+++ b/src/SlnUp.TestLibrary/SlnUp.TestLibrary.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
+  </ItemGroup>
+
+</Project>

--- a/src/SlnUp.Tests/ProgramOptionsTests.cs
+++ b/src/SlnUp.Tests/ProgramOptionsTests.cs
@@ -2,6 +2,7 @@ namespace SlnUp.Tests;
 
 using CommandLine;
 using FluentAssertions;
+using SlnUp.TestLibrary;
 using System.IO.Abstractions.TestingHelpers;
 using Xunit;
 
@@ -94,10 +95,10 @@ public class ProgramOptionsTests
     {
         // Arrange
         const string expectedVersion = "2022";
-        const string expectedFilePath = "C:/solution.sln";
+        string expectedFilePath = "C:/solution.sln".ToCrossPlatformPath();
 
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args);
+        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args.ToCrossPlatformPath().ToArray());
 
         // Assert
         Parsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<Parsed<ProgramOptions>>().Subject;
@@ -129,14 +130,15 @@ public class ProgramOptionsTests
     public void TryGetSlnUpOptions()
     {
         // Arrange
+        string expectedSolutionFilePath = "C:\\MyProject.sln".ToCrossPlatformPath();
         ProgramOptions programOptions = new()
         {
             Version = "16.8"
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            [expectedSolutionFilePath] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -144,7 +146,7 @@ public class ProgramOptionsTests
         // Assert
         result.Should().BeTrue();
         options.Should().NotBeNull();
-        options!.SolutionFilePath.Should().Be("C:\\MyProject.sln");
+        options!.SolutionFilePath.Should().Be(expectedSolutionFilePath);
         options.Version.Should().Be(Version.Parse("16.8.6"));
         options.BuildVersion.Should().Be(Version.Parse("16.8.31019.35"));
     }
@@ -154,6 +156,7 @@ public class ProgramOptionsTests
     public void TryGetSlnUpOptionsWithBuildVersion()
     {
         // Arrange
+        string expectedSolutionFilePath = "C:\\MyProject.sln".ToCrossPlatformPath();
         ProgramOptions programOptions = new()
         {
             Version = "0.0",
@@ -161,8 +164,8 @@ public class ProgramOptionsTests
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            [expectedSolutionFilePath] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -170,7 +173,7 @@ public class ProgramOptionsTests
         // Assert
         result.Should().BeTrue();
         options.Should().NotBeNull();
-        options!.SolutionFilePath.Should().Be("C:\\MyProject.sln");
+        options!.SolutionFilePath.Should().Be(expectedSolutionFilePath);
         options.Version.Should().Be(Version.Parse("0.0"));
         options.BuildVersion.Should().Be(Version.Parse("0.0.0.0"));
     }
@@ -180,6 +183,7 @@ public class ProgramOptionsTests
     public void TryGetSlnUpOptionsWithInvalidBuildVersion()
     {
         // Arrange
+        string expectedSolutionFilePath = "C:\\MyProject.sln".ToCrossPlatformPath();
         ProgramOptions programOptions = new()
         {
             Version = "0.0",
@@ -187,8 +191,8 @@ public class ProgramOptionsTests
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            [expectedSolutionFilePath] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -203,14 +207,15 @@ public class ProgramOptionsTests
     public void TryGetSlnUpOptionsWithInvalidVersion()
     {
         // Arrange
+        string expectedSolutionFilePath = "C:\\MyProject.sln".ToCrossPlatformPath();
         ProgramOptions programOptions = new()
         {
             Version = "0.0"
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            [expectedSolutionFilePath] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -225,15 +230,16 @@ public class ProgramOptionsTests
     public void TryGetSlnUpOptionsWithAbsoluteSolutionPath()
     {
         // Arrange
+        string expectedSolutionFilePath = "C:\\MyProject.sln".ToCrossPlatformPath();
         ProgramOptions programOptions = new()
         {
             Version = "16.8",
-            SolutionPath = "C:\\MyProject.sln"
+            SolutionPath = expectedSolutionFilePath
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            [expectedSolutionFilePath] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -241,7 +247,7 @@ public class ProgramOptionsTests
         // Assert
         result.Should().BeTrue();
         options.Should().NotBeNull();
-        options!.SolutionFilePath.Should().Be("C:\\MyProject.sln");
+        options!.SolutionFilePath.Should().Be(expectedSolutionFilePath);
     }
 
     // Multiple solution files available: > app 16.8
@@ -255,9 +261,9 @@ public class ProgramOptionsTests
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-            ["C:\\MyProject2.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            ["C:\\MyProject.sln".ToCrossPlatformPath()] = new MockFileData(string.Empty),
+            ["C:\\MyProject2.sln".ToCrossPlatformPath()] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -275,12 +281,12 @@ public class ProgramOptionsTests
         ProgramOptions programOptions = new()
         {
             Version = "16.8",
-            SolutionPath = "C:\\Missing.sln"
+            SolutionPath = "C:\\Missing.sln".ToCrossPlatformPath(),
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            ["C:\\MyProject.sln".ToCrossPlatformPath()] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -314,15 +320,16 @@ public class ProgramOptionsTests
     public void TryGetSlnUpOptionsWithRelativeSolutionPath()
     {
         // Arrange
+        string expectedSolutionFilePath = "C:\\MyProject.sln".ToCrossPlatformPath();
         ProgramOptions programOptions = new()
         {
             Version = "16.8",
-            SolutionPath = ".\\MyProject.sln"
+            SolutionPath = ".\\MyProject.sln".ToCrossPlatformPath(),
         };
         MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
         {
-            ["C:\\MyProject.sln"] = new MockFileData(string.Empty),
-        }, "C:\\");
+            [expectedSolutionFilePath] = new MockFileData(string.Empty),
+        }, "C:\\".ToCrossPlatformPath());
 
         // Act
         bool result = programOptions.TryGetSlnUpOptions(fileSystem, out SlnUpOptions? options);
@@ -330,6 +337,6 @@ public class ProgramOptionsTests
         // Assert
         result.Should().BeTrue();
         options.Should().NotBeNull();
-        options!.SolutionFilePath.Should().Be("C:\\MyProject.sln");
+        options!.SolutionFilePath.Should().Be(expectedSolutionFilePath);
     }
 }

--- a/src/SlnUp.Tests/SlnUp.Tests.csproj
+++ b/src/SlnUp.Tests/SlnUp.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SlnUp.TestLibrary\SlnUp.TestLibrary.csproj" />
     <ProjectReference Include="..\SlnUp\SlnUp.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This change makes the paths used in the tests cross-platform friendly so the tests can run on any platform. Introduced a new test library project to hold cross project type stuff.