### PR TITLE
Enable source link, package improvements, and analyzer warning fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,3 +122,9 @@ csharp_style_expression_bodied_operators = when_on_single_line
 
 # IDE0090: Use 'new(...)'
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = silent
+
+# CA1014: Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1014.severity = none

--- a/Packages.props
+++ b/Packages.props
@@ -5,6 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Globa dependencies -->
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub"       Version="1.1.1"
+                            PrivateAssets="All"/>
     <GlobalPackageReference Include="Nerdbank.GitVersioning"            Version="3.4.244"
                             PrivateAssets="all"
                             Condition=" '$(EnableGitVersioning)' != 'false' " />

--- a/build/Defaults.props
+++ b/build/Defaults.props
@@ -54,8 +54,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>6.0</AnalysisLevel>
-
-    <NoWarn>$(NoWarn);CA1014</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/Defaults.props
+++ b/build/Defaults.props
@@ -3,33 +3,69 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+
+    <!-- Determine if this is a CI build. -->
+    <IsCIBuild>false</IsCIBuild>
+    <IsCIBuild Condition="'$(FORCE_CI)' == 'true'"></IsCIBuild>
+    <IsCIBuild Condition="'$(TF_BUILD)' == 'true'">true</IsCIBuild>
+    <IsCIBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</IsCIBuild>
+
+    <!-- Sets the C# language version:
+      https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version#c-language-version-reference
+    -->
     <LangVersion>10.0</LangVersion>
+
+    <!-- Enable implicit usings:
+      https://docs.microsoft.com/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-rc1
+    -->
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- Enable nullable reference types: https://docs.microsoft.com/dotnet/csharp/nullable-references -->
     <Nullable>enable</Nullable>
+
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element). -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Embed source files that are not tracked by the source control manager in the PDB. -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Embed symbols containing Source Link in the main file (exe/dll). -->
     <DebugType>embedded</DebugType>
+
+    <!-- Generate XML documentation for not test projects. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateDocumentationFile Condition="$(MSBuildProjectName.EndsWith('.Tests'))">false</GenerateDocumentationFile>
+
+    <!-- Normalize file paths on CI builds. -->
+    <ContinuousIntegrationBuild>$(IsCIBuild)</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <PropertyGroup>
-    <MSBuildTreatWarningsAsErrors>false</MSBuildTreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors Condition="'$(AGENT_ID)' != ''">true</MSBuildTreatWarningsAsErrors>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <TreatWarningsAsErrors Condition="'$(AGENT_ID)' != ''">true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>$(IsCIBuild)</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors>$(IsCIBuild)</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Configure .NET source code analysis:
+      https://docs.microsoft.com/dotnet/fundamentals/code-analysis/overview
+    -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <CodeAnalysisTreatWarningsAsErrors>$(TreatWarningsAsErrors)</CodeAnalysisTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>6.0</AnalysisLevel>
+
+    <NoWarn>$(NoWarn);CA1014</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Package properties:
+      https://docs.microsoft.com/dotnet/standard/library-guidance/nuget
+      https://docs.microsoft.com/nuget/reference/msbuild-targets#pack-target-inputs
+    -->
     <Authors>Craig Treasure</Authors>
     <Owners>craigktreasure</Owners>
-    <ProjectUrl>https://github.com/craigktreasure/slnup</ProjectUrl>
-    <RepositoryUrl>https://github.com/craigktreasure/slnup.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/craigktreasure/SlnUp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/craigktreasure/SlnUp.git</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/SlnUp.Core.Tests/ArgumentTests.cs
+++ b/src/SlnUp.Core.Tests/ArgumentTests.cs
@@ -1,0 +1,71 @@
+namespace SlnUp.Core.Tests;
+
+using FluentAssertions;
+using Xunit;
+
+public class ArgumentTests
+{
+    [Fact]
+    public void NotNull()
+    {
+        // Arrange
+        int[] objectValue = Array.Empty<int>();
+
+        // Act and assert
+        Argument.NotNull(objectValue);
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("foo")]
+    public void NotNullOrEmpty(string objectValue)
+    {
+        // Act and assert
+        Argument.NotNullOrEmpty(objectValue);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NotNullOrEmptyThrows(string? objectValue)
+    {
+        // Act
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => Argument.NotNullOrEmpty(objectValue));
+
+        // Assert
+        ex.ParamName.Should().Be(nameof(objectValue));
+    }
+
+    [Fact]
+    public void NotNullOrWhiteSpace()
+    {
+        // Act and assert
+        Argument.NotNullOrWhiteSpace("foo");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void NotNullOrWhiteSpaceThrows(string? objectValue)
+    {
+        // Act
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => Argument.NotNullOrWhiteSpace(objectValue));
+
+        // Assert
+        ex.ParamName.Should().Be(nameof(objectValue));
+    }
+
+    [Fact]
+    public void NotNullThrows()
+    {
+        // Arrange
+        object? objectValue = null;
+
+        // Act
+        ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => Argument.NotNull(objectValue));
+
+        // Assert
+        ex.ParamName.Should().Be(nameof(objectValue));
+    }
+}

--- a/src/SlnUp.Core.Tests/ScopedActionTests.cs
+++ b/src/SlnUp.Core.Tests/ScopedActionTests.cs
@@ -34,4 +34,14 @@ public class ScopedActionTests
         // Assert
         actionCalled.Should().BeTrue();
     }
+
+    [Fact]
+    public void ScopedActionNull()
+    {
+        // Arrange
+        ScopedAction action = new(null!);
+
+        // Act and assert
+        action.Dispose();
+    }
 }

--- a/src/SlnUp.Core.Tests/VisualStudioVersionTests.cs
+++ b/src/SlnUp.Core.Tests/VisualStudioVersionTests.cs
@@ -143,6 +143,20 @@ public class VisualStudioVersionTests
     }
 
     [Fact]
+    public void GetHashCodeMethod()
+    {
+        // Arrange
+        VisualStudioVersion version = commonVersions[0];
+        int expectedHashCode = version.BuildVersion.GetHashCode();
+
+        // Act
+        int hashCode = version.GetHashCode();
+
+        // Assert
+        hashCode.Should().Be(expectedHashCode);
+    }
+
+    [Fact]
     public void ToJson()
     {
         // Act

--- a/src/SlnUp.Core/Argument.cs
+++ b/src/SlnUp.Core/Argument.cs
@@ -1,0 +1,62 @@
+namespace SlnUp.Core;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Class Argument.
+/// </summary>
+public static class Argument
+{
+    /// <summary>
+    /// Asserts the value is not null.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="value">The value.</param>
+    /// <param name="name">The name.</param>
+    /// <returns>The object if not null.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static T NotNull<T>([NotNull] T? value, [CallerArgumentExpression("value")] string name = "") where T : class
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(name);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Asserts the value is not null or empty.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <param name="name">The name.</param>
+    /// <returns><see cref="string"/>.</returns>
+    /// <exception cref="ArgumentException">The value cannot be null or empty.</exception>
+    public static string NotNullOrEmpty([NotNull] string? value, [CallerArgumentExpression("value")] string name = "")
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException("The value cannot be null or empty.", name);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Asserts the value is not null, empty, or white-space.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <param name="name">The name.</param>
+    /// <returns><see cref="string"/>.</returns>
+    /// <exception cref="ArgumentException">The value cannot be null, empty, or white-space.</exception>
+    public static string NotNullOrWhiteSpace([NotNull] string? value, [CallerArgumentExpression("value")] string name = "")
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("The value cannot be null, empty, or white-space.", name);
+        }
+
+        return value;
+    }
+}

--- a/src/SlnUp.Core/Extensions/RegexExtensions.cs
+++ b/src/SlnUp.Core/Extensions/RegexExtensions.cs
@@ -17,6 +17,8 @@ public static class RegexExtensions
     /// <returns><c>true</c> if the match was successful, <c>false</c> otherwise.</returns>
     public static bool TryMatch(this Regex regex, string input, [NotNullWhen(true)] out Match? match)
     {
+        ArgumentNullException.ThrowIfNull(regex);
+
         match = null;
         Match myMatch = regex.Match(input);
 

--- a/src/SlnUp.Core/Extensions/VersionExtensions.cs
+++ b/src/SlnUp.Core/Extensions/VersionExtensions.cs
@@ -14,7 +14,7 @@ public static class VersionExtensions
     /// <param name="other">The other.</param>
     /// <returns><c>true</c> if the major and minor versions are the same; otherwise, <c>false</c>.</returns>
     public static bool HasSameMajorMinor(this Version version, Version other)
-        => version.Major == other.Major && version.Minor == other.Minor;
+        => Argument.NotNull(version).Major == Argument.NotNull(other).Major && version.Minor == other.Minor;
 
     /// <summary>
     /// Determines if the version declares a 2-part version number.
@@ -22,7 +22,7 @@ public static class VersionExtensions
     /// <param name="version">The version.</param>
     /// <returns><c>true</c> if the version declares a 2-part version number, <c>false</c> otherwise.</returns>
     public static bool Is2PartVersion(this Version version)
-        => version.Major >= 0
+        => Argument.NotNull(version).Major >= 0
         && version.Minor >= 0
         && version.Build == -1
         && version.Revision == -1;
@@ -33,7 +33,7 @@ public static class VersionExtensions
     /// <param name="version">The version.</param>
     /// <returns><c>true</c> if the version declares a 3-part version number, <c>false</c> otherwise.</returns>
     public static bool Is3PartVersion(this Version version)
-        => version.Major >= 0
+        => Argument.NotNull(version).Major >= 0
         && version.Minor >= 0
         && version.Build >= 0
         && version.Revision == -1;
@@ -44,7 +44,7 @@ public static class VersionExtensions
     /// <param name="version">The version.</param>
     /// <returns><c>true</c> if the version declares a 4-part version number, <c>false</c> otherwise.</returns>
     public static bool Is4PartVersion(this Version version)
-        => version.Major >= 0
+        => Argument.NotNull(version).Major >= 0
         && version.Minor >= 0
         && version.Build >= 0
         && version.Revision >= 0;

--- a/src/SlnUp.Core/VisualStudioVersion.cs
+++ b/src/SlnUp.Core/VisualStudioVersion.cs
@@ -59,7 +59,7 @@ public record VisualStudioVersion(
     /// <param name="filePath">The file path.</param>
     /// <returns><see cref="IReadOnlyList{VisualStudioVersion}" />.</returns>
     public static IReadOnlyList<VisualStudioVersion> FromJsonFile(IFileSystem fileSystem, string filePath)
-        => FromJson(fileSystem.File.ReadAllText(filePath));
+        => FromJson(Argument.NotNull(fileSystem).File.ReadAllText(filePath));
 
     /// <summary>
     /// Returns a hash code for this instance.
@@ -81,7 +81,7 @@ public record VisualStudioVersion(
     /// <param name="versions">The versions.</param>
     /// <param name="filePath">The file path.</param>
     public static void ToJsonFile(IFileSystem fileSystem, IEnumerable<VisualStudioVersion> versions, string filePath)
-        => fileSystem.File.WriteAllText(filePath, ToJson(versions));
+        => Argument.NotNull(fileSystem).File.WriteAllText(filePath, ToJson(versions));
 
     /// <summary>
     /// Returns a <see cref="string" /> that represents this instance.

--- a/src/SlnUp.Tests/ProgramOptionsTests.cs
+++ b/src/SlnUp.Tests/ProgramOptionsTests.cs
@@ -32,8 +32,8 @@ public class ProgramOptionsTests
     {
         // Arrange
         string[] args = Array.Empty<string>();
-        StringWriter helpWriter = new();
-        Parser parser = new(config => config.HelpWriter = helpWriter);
+        using StringWriter helpWriter = new();
+        using Parser parser = new(config => config.HelpWriter = helpWriter);
 
         // Act
         ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args, parser);
@@ -72,8 +72,8 @@ public class ProgramOptionsTests
     {
         // Arrange
         string[] args = new[] { "--help" };
-        StringWriter helpWriter = new();
-        Parser parser = new(config => config.HelpWriter = helpWriter);
+        using StringWriter helpWriter = new();
+        using Parser parser = new(config => config.HelpWriter = helpWriter);
 
         // Act
         ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args, parser);

--- a/src/SlnUp/Program.cs
+++ b/src/SlnUp/Program.cs
@@ -2,6 +2,7 @@ namespace SlnUp;
 
 using CommandLine;
 using SlnUp.Core;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 
 internal static class Program
@@ -26,6 +27,7 @@ internal static class Program
         return Run(fileSystem, options);
     }
 
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "By design.")]
     internal static int Run(IFileSystem fileSystem, SlnUpOptions options)
     {
         try

--- a/src/SlnUp/ProgramOptions.cs
+++ b/src/SlnUp/ProgramOptions.cs
@@ -92,7 +92,7 @@ internal class ProgramOptions
             options = new SlnUpOptions(solutionFilePath, version.Version, version.BuildVersion);
         }
 
-        return options is not null;
+        return true;
     }
 
     private static bool TryResolveSolutionFilePath(IFileSystem fileSystem, string? input, [NotNullWhen(true)] out string? solutionFilePath)

--- a/src/SlnUp/SlnUp.csproj
+++ b/src/SlnUp/SlnUp.csproj
@@ -8,12 +8,14 @@
     <ToolCommandName>slnup</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A tool for updating Visual Studio version information in solution files.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Versions.json">
       <LogicalName>%(Identity)</LogicalName>
     </EmbeddedResource>
+    <None Include="$(SourceRootPath)README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VisualStudio.VersionScraper/ProgramOptions.cs
+++ b/src/VisualStudio.VersionScraper/ProgramOptions.cs
@@ -1,7 +1,9 @@
 namespace VisualStudio.VersionScraper;
 
 using CommandLine;
+using System.Diagnostics.CodeAnalysis;
 
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Created at runtime.")]
 internal class ProgramOptions
 {
     [Option("no-cache", HelpText = "Skip the cache when making requests.")]


### PR DESCRIPTION
This change enabled Source Link per the instructions [here](https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/), made some package improvements like including a README.md file, and fixes some additional analyzer warnings.