### PR TITLE
Bump version to 1.0.1-beta and pipeline adjustments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,8 +86,9 @@ jobs:
       - name: Configure GitHub NuGet registry
         run: nuget sources add -name github -source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json -username ${{ github.repository_owner }} -password ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push to GitHub package registry
+      - name: Push ${{ env.PACKAGE_VERSION }} to GitHub package registry
         run: nuget push __packages/NuGet/Release/SlnUp.*.nupkg -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source github
 
-      - name: Push to NuGet.org
+      - name: Push ${{ env.PACKAGE_VERSION }} to NuGet.org
+        if: ${{ !contains(env.PACKAGE_VERSION, '-') }}
         run: nuget push __packages/NuGet/Release/SlnUp.*.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,8 @@ jobs:
     name: 'Build SlnUp'
     runs-on: ubuntu-latest
 
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
     outputs:
       package_version: ${{steps.version.outputs.package_version}}
 
@@ -63,6 +65,8 @@ jobs:
     name: 'Release SlnUp'
     runs-on: ubuntu-latest
     needs: build
+
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'skip release')
 
     env:
       PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.0.1-beta.{height}",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
This change:

- Bumps the version to 1.0.1-beta.
- Allows skipping the CI entirely or just the release job.
- Only publish non-preview packages to NuGet.org.