### PR TITLE
Updated FluentAssertions to 6.4.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -24,7 +24,7 @@
                       IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"
                       PrivateAssets="all" />
     <PackageReference Update="Divergic.Logging.Xunit"                   Version="4.0.0" />
-    <PackageReference Update="FluentAssertions"                         Version="6.3.0" />
+    <PackageReference Update="FluentAssertions"                         Version="6.4.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                   Version="17.0.0" />
     <PackageReference Update="System.IO.Abstractions.TestingHelpers"    Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Update="xunit"                                    Version="2.4.1" />


### PR DESCRIPTION
  - This change updates FluentAssertions to [6.4.0](https://github.com/fluentassertions/fluentassertions/releases/tag/6.4.0).