### PR TITLE
Removed GitHub release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,38 +78,10 @@ jobs:
           name: __packages
           path: __packages
 
-  release_github:
-    name: 'Release SlnUp to GitHub'
-    runs-on: ubuntu-latest
-    needs: build
-
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'skip release')
-
-    env:
-      PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
-
-    steps:
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1
-        with:
-          nuget-version: latest
-
-      - name: Download __packages
-        uses: actions/download-artifact@v2
-        with:
-          name: __packages
-          path: __packages
-
-      - name: Configure GitHub NuGet registry
-        run: nuget sources add -name github -source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json -username ${{ github.repository_owner }} -password ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push ${{ env.PACKAGE_VERSION }} to GitHub package registry
-        run: nuget push __packages/NuGet/Release/SlnUp.*.nupkg -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source github
-
   release_nuget:
     name: 'Release SlnUp to NuGet.org'
     runs-on: ubuntu-latest
-    needs: release_github
+    needs: build
     environment:
       name: NuGet.org
       url: https://www.nuget.org/packages/SlnUp/


### PR DESCRIPTION
  - This change removes the push to the GitHub feed since it's completely useless and often broken.