### PR TITLE
Change .NET SDK version to a fixed version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ on:
 env:
   # Stop wasting time caching packages
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  SETUP_DOTNET_VERSION: 6.0.102
 
 jobs:
   build:
@@ -33,7 +34,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.x
+          dotnet-version: ${{ env.SETUP_DOTNET_VERSION }}
 
       - name: Set version
         id: version

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -5,6 +5,7 @@ on: pull_request
 env:
   # Stop wasting time caching packages
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  SETUP_DOTNET_VERSION: 6.0.102
 
 jobs:
   build:
@@ -24,7 +25,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.x
+          dotnet-version: ${{ env.SETUP_DOTNET_VERSION }}
 
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
  - This change adjusts the .NET SDK version installed to be fixed to 6.0.102 to workaround issues with `dotnet format` (see https://github.com/dotnet/format/issues/1519).