### PR TITLE
Added support for the VS 2017 header

### DIFF
--- a/Docs/Research.md
+++ b/Docs/Research.md
@@ -25,8 +25,8 @@ that we can update solution files with them appropriately.
 
 ## The Visual Studio solution file header
 
-According to the [documentation](https://docs.microsoft.com/visualstudio/extensibility/internals/solution-dot-sln-file?view=vs-2022#file-header), the file header usually looks
-like this:
+According to the [documentation](https://docs.microsoft.com/visualstudio/extensibility/internals/solution-dot-sln-file?view=vs-2022#file-header),
+the file header usually looks like this:
 
 ```
 Microsoft Visual Studio Solution File, Format Version 12.00
@@ -49,6 +49,23 @@ same major version, this value is not updated so as to lessen churn in the file.
 
 The minimum (oldest) version of Visual Studio that can open this solution file.
 > `MinimumVisualStudioVersion = 10.0.40219.1`
+
+This is accurate for Visual Studio 2019 and 2022.
+
+### Visual Studio 2017
+
+Visual Studio 2017 has a slight variation of the file header, which is documented
+[here](https://docs.microsoft.com/visualstudio/extensibility/internals/solution-dot-sln-file?view=vs-2017#file-header).
+
+```
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.15
+MinimumVisualStudioVersion = 10.0.40219.1
+```
+
+Note the difference in the major version most recently saved: `# Visual Studio 15`
+vs `# Visual Studio Version 16` for Visual Studio 2019 and above.
 
 ## Common solution sources
 

--- a/src/SlnUp/ProgramOptions.cs
+++ b/src/SlnUp/ProgramOptions.cs
@@ -14,7 +14,7 @@ internal class ProgramOptions
     public string? SolutionPath { get; set; }
 
     [Value(0, Required = true, MetaName = "version", HelpText = "The Visual Studio version to update the solution file"
-        + "with. Should be either a 2 or 3-part version number or a product year.")]
+        + "with. Should be either a 2 or 3-part version number (ex. 16.9 or 17.0.1) or a product year (ex. 2017, 2019, or 2022).")]
     public string? Version { get; set; }
 
     /// <summary>

--- a/src/SlnUp/SolutionFile.cs
+++ b/src/SlnUp/SolutionFile.cs
@@ -16,7 +16,7 @@ internal class SolutionFile
         RegexOptions.Compiled);
 
     private static readonly Regex lastVisualStudioMajorVersionRegex = new(
-        @"^# Visual Studio Version (\d+)$",
+        @"^# Visual Studio(?: Version)? (\d+)$",
         RegexOptions.Compiled);
 
     private static readonly Regex lastVisualStudioVersionRegex = new(
@@ -85,7 +85,11 @@ internal class SolutionFile
         string fileFormatVersionLine = $"Microsoft Visual Studio Solution File, Format Version {fileHeader.FileFormatVersion}";
         lines[this.fileFormatLineNumber] = fileFormatVersionLine;
 
-        string lastVisualStudioMajorVersionLine = $"# Visual Studio Version {fileHeader.LastVisualStudioMajorVersion}";
+        string lastVisualStudioMajorVersionLine = fileHeader.LastVisualStudioMajorVersion switch
+        {
+            >= 16 => $"# Visual Studio Version {fileHeader.LastVisualStudioMajorVersion}",
+            <= 15 => $"# Visual Studio {fileHeader.LastVisualStudioMajorVersion}",
+        };
         lines[this.fileFormatLineNumber + 1] = lastVisualStudioMajorVersionLine;
 
         string lastVisualStudioVersionLine = $"VisualStudioVersion = {fileHeader.LastVisualStudioVersion}";


### PR DESCRIPTION
Due to a slight variation in the Visual Studio 2017 file header, which I missed, we couldn't properly parse the version information from a 2017 file header. The portion containing the line for the major version used to indicate the solution icon does not contain the word "Version" like in 2019 and 2022. This change allows us to handle the 2017 variation.

This addresses #58.