### PR TITLE
Use `dotnet-format`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "nbgv"
       ]
+    },
+    "dotnet-format": {
+      "version": "6.3.315103",
+      "commands": [
+        "dotnet-format"
+      ]
     }
   }
 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,8 +46,11 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
+      - name: Install .NET tools
+        run: dotnet tool restore
+
       - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+        run: dotnet dotnet-format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,6 @@ on:
 env:
   # Stop wasting time caching packages
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  SETUP_DOTNET_VERSION: 6.0.102
 
 jobs:
   build:
@@ -34,7 +33,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.SETUP_DOTNET_VERSION }}
+          dotnet-version: 6.x
 
       - name: Set version
         id: version

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
+      - name: Install .NET tools
+        run: dotnet tool restore
+
       - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+        run: dotnet dotnet-format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -5,7 +5,6 @@ on: pull_request
 env:
   # Stop wasting time caching packages
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  SETUP_DOTNET_VERSION: 6.0.102
 
 jobs:
   build:
@@ -25,7 +24,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.SETUP_DOTNET_VERSION }}
+          dotnet-version: 6.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "6.0.201",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,14 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet6">
+      <package pattern="dotnet-format" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
  - This change updates to the latest .NET SDK and re-enables the use of the latest in the pipelines.
  - Due to https://github.com/dotnet/sdk/issues/23972 and https://github.com/dotnet/format/issues/1519, I'm going to start using the `dotnet-format` tool instead of the version integrated into the SDK. Because I'm pedantic, I'm using the new [source mapping](https://docs.microsoft.com/nuget/release-notes/nuget-6.0#source-mapping) feature of NuGet 6.0 so that I don't inadvertently pull more than I want through the `dotnet6` feed.