### PR TITLE
Dependabot: Added github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: nuget
+- package-ecosystem:
+    - nuget
+    - github-actions
   directory: "/"
   schedule:
     interval: weekly
     time: '13:00'
   open-pull-requests-limit: 10
   reviewers:
-  - craigktreasure
+    - craigktreasure
   assignees:
-  - craigktreasure
+    - craigktreasure


### PR DESCRIPTION
  - This change adds the `github-actions` [ecosystem](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem) for Dependabot.