### PR TITLE
Update CentralBuildOutput to 0.1.1-beta.7

### DIFF
--- a/build/Defaults.props
+++ b/build/Defaults.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-
     <!-- Determine if this is a CI build. -->
     <IsCIBuild>false</IsCIBuild>
     <IsCIBuild Condition="'$(FORCE_CI)' == 'true'"></IsCIBuild>

--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.1.3",
-    "Treasure.Build.CentralBuildOutput" : "0.1.1-beta.3"
+    "Treasure.Build.CentralBuildOutput" : "0.1.1-beta.7"
   }
 }


### PR DESCRIPTION
  - This change updates Treasure.Build.CentralBuildOutput to  0.1.1-beta.7, which handles configuration and platform better when they're not explicitly set.