### PR TITLE
Change back to `dotnet format`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,12 +7,6 @@
       "commands": [
         "nbgv"
       ]
-    },
-    "dotnet-format": {
-      "version": "6.3.315103",
-      "commands": [
-        "dotnet-format"
-      ]
     }
   }
 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,11 +46,8 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: Install .NET tools
-        run: dotnet tool restore
-
       - name: DotNet Format
-        run: dotnet dotnet-format --no-restore --verify-no-changes
+        run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: Install .NET tools
-        run: dotnet tool restore
-
       - name: DotNet Format
-        run: dotnet dotnet-format --no-restore --verify-no-changes
+        run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.201",
+    "version": "6.0.202",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },

--- a/nuget.config
+++ b/nuget.config
@@ -3,14 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="nuget">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet6">
-      <package pattern="dotnet-format" />
-    </packageSource>
-  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
  - .NET SDK 6.0.202 fixed `dotnet format`, so we can now switch back.