### PR TITLE
Convert to System.CommandLine

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -12,9 +12,9 @@
                             Condition=" '$(EnableGitVersioning)' != 'false' " />
 
     <!-- Project dependencies -->
-    <PackageReference Update="CommandLineParser"                        Version="2.9.1" />
     <PackageReference Update="Humanizer.Core"                           Version="2.14.1" />
     <PackageReference Update="HtmlAgilityPack"                          Version="1.11.43" />
+    <PackageReference Update="System.CommandLine"                       Version="2.0.0-beta4.22272.1" />
     <PackageReference Update="System.IO.Abstractions"                   Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Update="System.Text.Json"                         Version="6.0.5" />
     <PackageReference Update="Treasure.Utils.Argument"                  Version="0.2.3" />
@@ -27,7 +27,7 @@
     <PackageReference Update="FluentAssertions"                         Version="6.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                   Version="17.2.0" />
     <PackageReference Update="System.IO.Abstractions.TestingHelpers"    Version="$(SystemIOAbstractionsVersion)" />
-    <PackageReference Update="xunit"                                    Version="2.4.1" />
+    <PackageReference Update="xunit"                                    Version="2.4.2-pre.12" />
     <PackageReference Update="xunit.runner.visualstudio"                Version="2.4.5"
                       IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"
                       PrivateAssets="all" />

--- a/src/SlnUp.Tests/ProgramOptionsTests.cs
+++ b/src/SlnUp.Tests/ProgramOptionsTests.cs
@@ -1,108 +1,103 @@
 namespace SlnUp.Tests;
 
-using CommandLine;
 using FluentAssertions;
 using SlnUp.TestLibrary;
+using SlnUp.Tests.Utilities;
+using System.CommandLine;
+using System.CommandLine.IO;
 using System.IO.Abstractions.TestingHelpers;
 using Xunit;
 
 public class ProgramOptionsTests
 {
+    private readonly TestConsole testConsole = new();
+
     [Theory]
     [InlineData("2022")]
     [InlineData("17.0")]
-    public void ParseOptions(string version)
+    public void Configure(string version)
     {
         // Arrange
         string[] args = new[] { version };
 
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args);
+        ProgramOptions? result = this.ConfigureAndInvoke(args);
 
         // Assert
-        Parsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<Parsed<ProgramOptions>>().Subject;
-        result.Value.Should().BeEquivalentTo(new ProgramOptions
+        Assert.NotNull(result);
+        result.Should().BeEquivalentTo(new ProgramOptions
         {
             Version = version
         });
     }
 
     [Fact]
-    public void ParseOptionsNoParameters()
+    public void ConfigureNoParameters()
     {
         // Arrange
         string[] args = Array.Empty<string>();
-        using StringWriter helpWriter = new();
-        using Parser parser = new(config => config.HelpWriter = helpWriter);
 
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args, parser);
-        string helpContent = helpWriter.ToString();
+        ProgramOptions? result = this.ConfigureAndInvoke(args);
 
         // Assert
-        NotParsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<NotParsed<ProgramOptions>>().Subject;
-        Error error = result.Errors.Should().ContainSingle().Subject;
-        error.Tag.Should().Be(ErrorType.MissingRequiredOptionError);
-        helpContent.Should().NotBeNullOrEmpty();
+        Assert.Null(result);
+        this.testConsole.Should().HaveOutputWritten();
+        this.testConsole.GetErrorOutput().Should().StartWith("Required argument missing for command");
     }
 
     [Theory]
     [InlineData("2022", "--build-version", "17.0.31903.59")]
     [InlineData("--build-version", "17.0.31903.59", "2022")]
-    public void ParseOptionsWithBuildVersion(params string[] args)
+    public void ConfigureWithBuildVersion(params string[] args)
     {
         // Arrange
         const string expectedVersion = "2022";
         const string expectedBuildVersion = "17.0.31903.59";
 
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args);
+        ProgramOptions? result = this.ConfigureAndInvoke(args);
 
         // Assert
-        Parsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<Parsed<ProgramOptions>>().Subject;
-        result.Value.Should().BeEquivalentTo(new ProgramOptions
+        Assert.NotNull(result);
+        result.Should().BeEquivalentTo(new ProgramOptions
         {
             Version = expectedVersion,
             BuildVersion = Version.Parse(expectedBuildVersion),
         });
     }
 
-    [Fact]
-    public void ParseOptionsWithHelp()
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    [InlineData("-?")]
+    public void ConfigureWithHelp(params string[] args)
     {
-        // Arrange
-        string[] args = new[] { "--help" };
-        using StringWriter helpWriter = new();
-        using Parser parser = new(config => config.HelpWriter = helpWriter);
-
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args, parser);
-        string helpContent = helpWriter.ToString();
+        ProgramOptions? result = this.ConfigureAndInvoke(args);
 
         // Assert
-        NotParsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<NotParsed<ProgramOptions>>().Subject;
-        Error error = result.Errors.Should().ContainSingle().Subject;
-        error.StopsProcessing.Should().BeTrue();
-        error.Tag.Should().Be(ErrorType.HelpRequestedError);
-        helpContent.Should().NotBeNullOrEmpty();
+        Assert.Null(result);
+        this.testConsole.GetOutput().Should().StartWith("Description:");
+        this.testConsole.Should().NotHaveErrorWritten();
     }
 
     [Theory]
     [InlineData("2022", "--path", "C:/solution.sln")]
     [InlineData("2022", "-p", "C:/solution.sln")]
     [InlineData("-p", "C:/solution.sln", "2022")]
-    public void ParseOptionsWithPath(params string[] args)
+    public void ConfigureWithPath(params string[] args)
     {
         // Arrange
         const string expectedVersion = "2022";
         string expectedFilePath = "C:/solution.sln".ToCrossPlatformPath();
 
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args.ToCrossPlatformPath().ToArray());
+        ProgramOptions? result = this.ConfigureAndInvoke(args.ToCrossPlatformPath().ToArray());
 
         // Assert
-        Parsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<Parsed<ProgramOptions>>().Subject;
-        result.Value.Should().BeEquivalentTo(new ProgramOptions
+        Assert.NotNull(result);
+        result.Should().BeEquivalentTo(new ProgramOptions
         {
             Version = expectedVersion,
             SolutionPath = expectedFilePath,
@@ -110,19 +105,17 @@ public class ProgramOptionsTests
     }
 
     [Fact]
-    public void ParseOptionsWithVersion()
+    public void ConfigureWithVersion()
     {
         // Arrange
         string[] args = new[] { "--version" };
 
         // Act
-        ParserResult<ProgramOptions> parseResult = ProgramOptions.ParseOptions(args);
+        ProgramOptions? result = this.ConfigureAndInvoke(args);
 
         // Assert
-        NotParsed<ProgramOptions> result = parseResult.Should().BeAssignableTo<NotParsed<ProgramOptions>>().Subject;
-        Error error = result.Errors.Should().ContainSingle().Subject;
-        error.StopsProcessing.Should().BeTrue();
-        error.Tag.Should().Be(ErrorType.VersionRequestedError);
+        Assert.Null(result);
+        this.testConsole.Should().HaveOutputWritten();
     }
 
     /// <summary>
@@ -382,5 +375,21 @@ public class ProgramOptionsTests
         result.Should().BeTrue();
         options.Should().NotBeNull();
         options!.SolutionFilePath.Should().Be(expectedSolutionFilePath);
+    }
+
+    private ProgramOptions? ConfigureAndInvoke(string[] args)
+        => this.ConfigureAndInvoke(args, out _);
+
+    private ProgramOptions? ConfigureAndInvoke(string[] args, out int exitCode)
+    {
+        ProgramOptions? options = null;
+
+        exitCode = ProgramOptions.Configure(opts =>
+        {
+            options = opts;
+            return 0;
+        }).Invoke(args, this.testConsole);
+
+        return options;
     }
 }

--- a/src/SlnUp.Tests/Utilities/ConsoleAssertions.cs
+++ b/src/SlnUp.Tests/Utilities/ConsoleAssertions.cs
@@ -1,0 +1,27 @@
+namespace SlnUp.Tests.Utilities;
+
+using FluentAssertions;
+using FluentAssertions.Primitives;
+using System.CommandLine;
+
+internal class ConsoleAssertions : ReferenceTypeAssertions<IConsole, ConsoleAssertions>
+{
+    protected override string Identifier => nameof(IConsole);
+
+    public ConsoleAssertions(IConsole console)
+            : base(console)
+    {
+    }
+
+    public void HaveErrorWritten()
+        => this.Subject.GetErrorOutput().Should().NotBeNullOrEmpty();
+
+    public void HaveOutputWritten()
+        => this.Subject.GetOutput().Should().NotBeNullOrEmpty();
+
+    public void NotHaveErrorWritten()
+        => this.Subject.GetErrorOutput().Should().BeNullOrEmpty();
+
+    public void NotHaveOutputWritten()
+        => this.Subject.GetOutput().Should().BeNullOrEmpty();
+}

--- a/src/SlnUp.Tests/Utilities/TestConsoleExtensions.cs
+++ b/src/SlnUp.Tests/Utilities/TestConsoleExtensions.cs
@@ -1,0 +1,14 @@
+namespace SlnUp.Tests.Utilities;
+
+using FluentAssertions;
+using System.CommandLine;
+using System.CommandLine.IO;
+
+internal static class TestConsoleExtensions
+{
+    public static string GetErrorOutput(this IConsole console) => console.Error.ToString()!;
+
+    public static string GetOutput(this IConsole console) => console.Out.ToString()!;
+
+    public static ConsoleAssertions Should(this IConsole console) => new(console);
+}

--- a/src/SlnUp/Program.cs
+++ b/src/SlnUp/Program.cs
@@ -1,7 +1,7 @@
 namespace SlnUp;
 
-using CommandLine;
 using SlnUp.Core;
+using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 
@@ -11,7 +11,7 @@ internal static class Program
     {
         Console.Title = "Visual Studio Solution Updater";
 
-        return ProgramOptions.ParseOptions(args).MapResult(Run, _ => 1);
+        return ProgramOptions.Configure(Run).Invoke(args);
     }
 
     private static int Run(ProgramOptions options)

--- a/src/SlnUp/ProgramOptions.cs
+++ b/src/SlnUp/ProgramOptions.cs
@@ -29,13 +29,14 @@ internal class ProgramOptions
             description: "Uses version information as specified with this build version number.",
             parseArgument: result =>
             {
-                if (System.Version.TryParse(result.Tokens.Single().Value, out Version? version))
+                string tokenValue = result.Tokens.Single().Value;
+                if (System.Version.TryParse(tokenValue, out Version? version))
                 {
                     return version;
                 }
                 else
                 {
-                    result.ErrorMessage = $"The argument format is not valid: '{result.Argument.Name}'.";
+                    result.ErrorMessage = $"Cannot parse argument '{tokenValue}' for option '{result.Argument.Name}' as expected type '{result.Argument.ValueType}'.";
                     return null;
                 }
             });
@@ -50,16 +51,10 @@ internal class ProgramOptions
             versionArgument
         };
 
-        rootCommand.SetHandler((string? version, string? path, Version? buildVersion) =>
+        rootCommand.SetHandler(options =>
         {
-            ProgramOptions options = new()
-            {
-                BuildVersion = buildVersion,
-                SolutionPath = path,
-                Version = version,
-            };
-            invokeAction(options);
-        }, versionArgument, pathOption, buildVersionOption);
+            return Task.FromResult(invokeAction(options));
+        }, new ProgramOptionsBinder(pathOption, versionArgument, buildVersionOption));
 
         return rootCommand;
     }

--- a/src/SlnUp/ProgramOptionsBinder.cs
+++ b/src/SlnUp/ProgramOptionsBinder.cs
@@ -1,0 +1,31 @@
+namespace SlnUp;
+
+using System;
+using System.CommandLine;
+using System.CommandLine.Binding;
+
+internal class ProgramOptionsBinder : BinderBase<ProgramOptions>
+{
+    private readonly Option<Version?> buildVersionOption;
+
+    private readonly Option<string?> pathOption;
+
+    private readonly Argument<string?> versionArgument;
+
+    public ProgramOptionsBinder(
+        Option<string?> pathOption,
+        Argument<string?> versionArgument,
+        Option<Version?> buildVersionOption)
+    {
+        this.pathOption = pathOption;
+        this.versionArgument = versionArgument;
+        this.buildVersionOption = buildVersionOption;
+    }
+
+    protected override ProgramOptions GetBoundValue(BindingContext bindingContext) => new()
+    {
+        BuildVersion = bindingContext.ParseResult.GetValueForOption(this.buildVersionOption),
+        SolutionPath = bindingContext.ParseResult.GetValueForOption(this.pathOption),
+        Version = bindingContext.ParseResult.GetValueForArgument(this.versionArgument),
+    };
+}

--- a/src/SlnUp/SlnUp.csproj
+++ b/src/SlnUp/SlnUp.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 

--- a/src/VisualStudio.VersionScraper/Program.cs
+++ b/src/VisualStudio.VersionScraper/Program.cs
@@ -1,7 +1,7 @@
 namespace VisualStudio.VersionScraper;
 
-using CommandLine;
 using SlnUp.Core;
+using System.CommandLine;
 using System.IO.Abstractions;
 
 internal static class Program
@@ -10,7 +10,7 @@ internal static class Program
     {
         Console.Title = "Visual Studio Version Scraper";
 
-        return ProgramOptions.ParseOptions(args).MapResult(Run, _ => 1);
+        return ProgramOptions.Configure(Run).Invoke(args);
     }
 
     private static int Run(ProgramOptions options)

--- a/src/VisualStudio.VersionScraper/ProgramOptions.cs
+++ b/src/VisualStudio.VersionScraper/ProgramOptions.cs
@@ -1,17 +1,41 @@
 namespace VisualStudio.VersionScraper;
 
-using CommandLine;
+using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Created at runtime.")]
 internal class ProgramOptions
 {
-    [Option("no-cache", HelpText = "Skip the cache when making requests.")]
     public bool NoCache { get; set; }
 
-    [Value(0, MetaName = "output", Required = true, HelpText = "Json file output path.")]
     public string? OutputFilePath { get; set; }
 
-    public static ParserResult<ProgramOptions> ParseOptions(string[] args)
-        => Parser.Default.ParseArguments<ProgramOptions>(args);
+    public static RootCommand Configure(Func<ProgramOptions, int> invokeAction)
+    {
+        Argument<string?> outputArgument = new(
+            name: "output",
+            description: "Json file output path.");
+
+        Option<bool> noCacheOption = new(
+            name: "--no-cache",
+            description: "Skip the cache when making requests.");
+
+        RootCommand rootCommand = new("Visual Studio Version Scraper")
+        {
+            outputArgument,
+            noCacheOption
+        };
+
+        rootCommand.SetHandler((string? jsonOutput, bool noCache) =>
+        {
+            ProgramOptions options = new()
+            {
+                NoCache = noCache,
+                OutputFilePath = jsonOutput,
+            };
+            invokeAction(options);
+        }, outputArgument, noCacheOption);
+
+        return rootCommand;
+    }
 }

--- a/src/VisualStudio.VersionScraper/ProgramOptions.cs
+++ b/src/VisualStudio.VersionScraper/ProgramOptions.cs
@@ -26,15 +26,10 @@ internal class ProgramOptions
             noCacheOption
         };
 
-        rootCommand.SetHandler((string? jsonOutput, bool noCache) =>
+        rootCommand.SetHandler(options =>
         {
-            ProgramOptions options = new()
-            {
-                NoCache = noCache,
-                OutputFilePath = jsonOutput,
-            };
-            invokeAction(options);
-        }, outputArgument, noCacheOption);
+            return Task.FromResult(invokeAction(options));
+        }, new ProgramOptionsBinder(outputArgument, noCacheOption));
 
         return rootCommand;
     }

--- a/src/VisualStudio.VersionScraper/ProgramOptionsBinder.cs
+++ b/src/VisualStudio.VersionScraper/ProgramOptionsBinder.cs
@@ -1,0 +1,26 @@
+namespace VisualStudio.VersionScraper;
+
+using System;
+using System.CommandLine;
+using System.CommandLine.Binding;
+
+internal class ProgramOptionsBinder : BinderBase<ProgramOptions>
+{
+    private readonly Option<bool> noCacheOption;
+
+    private readonly Argument<string?> outputArgument;
+
+    public ProgramOptionsBinder(
+        Argument<string?> outputArgument,
+        Option<bool> noCacheOption)
+    {
+        this.outputArgument = outputArgument;
+        this.noCacheOption = noCacheOption;
+    }
+
+    protected override ProgramOptions GetBoundValue(BindingContext bindingContext) => new()
+    {
+        OutputFilePath = bindingContext.ParseResult.GetValueForArgument(this.outputArgument),
+        NoCache = bindingContext.ParseResult.GetValueForOption(this.noCacheOption),
+    };
+}

--- a/src/VisualStudio.VersionScraper/VisualStudio.VersionScraper.csproj
+++ b/src/VisualStudio.VersionScraper/VisualStudio.VersionScraper.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" />
     <PackageReference Include="HtmlAgilityPack" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.2-beta.{height}",
+  "version": "1.3.0-beta.{height}",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
This change converts CLI handling to use [System.CommandLine](https://docs.microsoft.com/dotnet/standard/commandline/) and updates the version to `1.3.0-beta`.