### PR TITLE
Default the version argument to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,16 @@ To view all available options, you can run:
 slnup --help
 ```
 
-The simplest form is to run the tool (`slnup`) with a Visual Studio product year
-(2017, 2019, or 2022). This will cause the tool to discover a solution file in
-the current directory and update it with the latest version for the specified
-product year.
+The simplest form is to run the tool (`slnup`) from a directory containing a
+single solution (`.sln`) file. This will cause the tool to discover a solution
+file in the current directory and update it with the latest version.
+
+```shell
+slnup
+```
+
+You can also pass a Visual Studio product year (2017, 2019, or 2022) to update
+to the latest version for the specified product year.
 
 ```shell
 slnup 2022
@@ -67,7 +73,8 @@ slnup 17.0
 ```
 
 A path to a solution file may also be specified using the `-p` or `--path`
-parameters.
+parameters. This will be necessary if there is more than one solution file
+in the current directory.
 
 ```shell
 slnup 2022 --path ./path/to/solution.sln

--- a/src/SlnUp/CLI/ProgramOptions.cs
+++ b/src/SlnUp/CLI/ProgramOptions.cs
@@ -9,6 +9,8 @@ using System.IO.Abstractions;
 
 internal class ProgramOptions
 {
+    public const string DefaultVersionArgument = "2022";
+
     public Version? BuildVersion { get; set; }
 
     public string? SolutionPath { get; set; }
@@ -24,7 +26,8 @@ internal class ProgramOptions
 
         Argument<string?> versionArgument = new(
             name: "version",
-            description: "The Visual Studio version to update the solution file with. Should be either a 2 or 3-part version number (ex. 16.9 or 17.0.1) or a product year (ex. 2017, 2019, or 2022).");
+            getDefaultValue: () => DefaultVersionArgument,
+            description: "The Visual Studio version to update the solution file with. Can be either a product year (ex. 2017, 2019, or 2022) or a 2 or 3-part version number (ex. 16.9 or 17.0.1).");
 
         Option<Version?> buildVersionOption = new(
             name: "--build-version",

--- a/tests/SlnUp.Tests/CLI/ProgramOptionsBinderTests.cs
+++ b/tests/SlnUp.Tests/CLI/ProgramOptionsBinderTests.cs
@@ -32,15 +32,17 @@ public class ProgramOptionsBinderTests
     }
 
     [Theory]
+    [InlineData(null, null, null)]
     [InlineData("2022", null, null)]
     [InlineData("2022", null, "17.2.0")]
     [InlineData("2022", "C:/path.sln", null)]
     [InlineData("2022", "C:/path.sln", "17.2.0")]
-    public void GetBoundValue(string expectedVersion, string? expectedPath, string? expectedBuildVersion)
+    public void GetBoundValue(string? version, string? expectedPath, string? expectedBuildVersion)
     {
         // Arrange
+        string expectedVersion = version ?? ProgramOptions.DefaultVersionArgument;
         Option<string?> pathOption = new("--path");
-        Argument<string?> versionArgument = new("version");
+        Argument<string?> versionArgument = new("version", getDefaultValue: () => ProgramOptions.DefaultVersionArgument);
         Option<Version?> buildVersionOption = new("--build-version", parseArgument: ArgumentParser.ParseVersion);
         RootCommand command = new()
         {
@@ -49,7 +51,7 @@ public class ProgramOptionsBinderTests
             buildVersionOption,
         };
         ProgramOptionsBinder binder = new(pathOption, versionArgument, buildVersionOption);
-        StringBuilder argsBuilder = new(expectedVersion);
+        StringBuilder argsBuilder = new(version);
 
         if (expectedPath is not null)
         {

--- a/tests/SlnUp.Tests/CLI/ProgramOptionsTests.cs
+++ b/tests/SlnUp.Tests/CLI/ProgramOptionsTests.cs
@@ -41,10 +41,12 @@ public class ProgramOptionsTests
         ProgramOptions? result = this.ConfigureAndInvoke(args, out int exitCode);
 
         // Assert
-        Assert.Equal(1, exitCode);
-        Assert.Null(result);
-        this.testConsole.Should().HaveOutputWritten();
-        this.testConsole.GetErrorOutput().Should().StartWith("Required argument missing for command");
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(result);
+        result.Should().BeEquivalentTo(new ProgramOptions
+        {
+            Version = ProgramOptions.DefaultVersionArgument,
+        });
     }
 
     [Theory]


### PR DESCRIPTION
  - This change drops the requirement of the `version` argument meaning you can just run `slnup` to update a solution to the latest available version. Today, that is the latest of the 2022 version.