### PR TITLE
Update to .NET 7

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.4.244",
+      "version": "3.5.119",
       "commands": [
         "nbgv"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -124,7 +124,7 @@ csharp_style_expression_bodied_operators = when_on_single_line
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 
 # CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1303.severity = silent
+dotnet_diagnostic.CA1303.severity = none
 
 # CA1014: Mark assemblies with CLSCompliantAttribute
 dotnet_diagnostic.CA1014.severity = none

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,10 +30,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.x
+
+      - name: Setup .NET 7
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 67.x
 
       - name: Set version
         id: version

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -21,10 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.x
+
+      - name: Setup .NET 7
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/Packages.props
+++ b/Packages.props
@@ -16,7 +16,7 @@
     <PackageReference Update="HtmlAgilityPack"                          Version="1.11.46" />
     <PackageReference Update="System.CommandLine"                       Version="2.0.0-beta4.22272.1" />
     <PackageReference Update="System.IO.Abstractions"                   Version="$(SystemIOAbstractionsVersion)" />
-    <PackageReference Update="System.Text.Json"                         Version="6.0.6" />
+    <PackageReference Update="System.Text.Json"                         Version="7.0.0" />
     <PackageReference Update="Treasure.Utils.Argument"                  Version="1.0.0" />
 
     <!-- Test dependencies -->

--- a/build/Defaults.props
+++ b/build/Defaults.props
@@ -10,7 +10,7 @@
     <!-- Sets the C# language version:
       https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version#c-language-version-reference
     -->
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
 
     <!-- Enable implicit usings:
       https://docs.microsoft.com/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-rc1
@@ -50,7 +50,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>6.0</AnalysisLevel>
+    <AnalysisLevel>7.0</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.202",
+    "version": "7.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },

--- a/src/SlnUp.Core/SlnUp.Core.csproj
+++ b/src/SlnUp.Core/SlnUp.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SlnUp.Json/SlnUp.Json.csproj
+++ b/src/SlnUp.Json/SlnUp.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SlnUp/SlnUp.csproj
+++ b/src/SlnUp/SlnUp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>slnup</ToolCommandName>

--- a/src/VisualStudio.VersionScraper/ProgramOptions.cs
+++ b/src/VisualStudio.VersionScraper/ProgramOptions.cs
@@ -4,7 +4,7 @@ using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Created at runtime.")]
-internal class ProgramOptions
+internal sealed class ProgramOptions
 {
     public OutputFormat Format { get; set; }
 

--- a/src/VisualStudio.VersionScraper/ProgramOptionsBinder.cs
+++ b/src/VisualStudio.VersionScraper/ProgramOptionsBinder.cs
@@ -3,7 +3,7 @@ namespace VisualStudio.VersionScraper;
 using System.CommandLine;
 using System.CommandLine.Binding;
 
-internal class ProgramOptionsBinder : BinderBase<ProgramOptions>
+internal sealed class ProgramOptionsBinder : BinderBase<ProgramOptions>
 {
     private readonly Option<bool> noCacheOption;
 

--- a/src/VisualStudio.VersionScraper/VisualStudio.VersionScraper.csproj
+++ b/src/VisualStudio.VersionScraper/VisualStudio.VersionScraper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/VisualStudio.VersionScraper/VisualStudioVersionDocScraper.cs
+++ b/src/VisualStudio.VersionScraper/VisualStudioVersionDocScraper.cs
@@ -5,7 +5,7 @@ using SlnUp.Core;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
-internal class VisualStudioVersionDocScraper
+internal sealed class VisualStudioVersionDocScraper
 {
     private const string vs2017VersionsDocUrl = "https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2017/install/visual-studio-build-numbers-and-release-dates";
 

--- a/src/VisualStudio.VersionScraper/Writers/CSharp/CSharpVersionWriter.cs
+++ b/src/VisualStudio.VersionScraper/Writers/CSharp/CSharpVersionWriter.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Treasure.Utils;
 
-internal class CSharpVersionWriter
+internal sealed class CSharpVersionWriter
 {
     private const string ClassName = "VersionManager";
 

--- a/src/VisualStudio.VersionScraper/Writers/CSharp/CSharpVersionWriter.cs
+++ b/src/VisualStudio.VersionScraper/Writers/CSharp/CSharpVersionWriter.cs
@@ -55,7 +55,8 @@ internal sealed class CSharpVersionWriter
             {
                 foreach (VisualStudioVersion version in versions)
                 {
-                    writer.WriteLine($"new {nameof(VisualStudioVersion)}({nameof(VisualStudioProduct)}.{version.Product}, Version.Parse(\"{version.Version}\"), Version.Parse(\"{version.BuildVersion}\"), \"{version.Channel}\", {version.IsPreview.ToString().ToLower()}),");
+                    string isPreview = version.IsPreview ? "true" : "false";
+                    writer.WriteLine($"new {nameof(VisualStudioVersion)}({nameof(VisualStudioProduct)}.{version.Product}, Version.Parse(\"{version.Version}\"), Version.Parse(\"{version.BuildVersion}\"), \"{version.Channel}\", {isPreview}),");
                 }
             }
         }

--- a/src/VisualStudio.VersionScraper/Writers/CodeWriter.cs
+++ b/src/VisualStudio.VersionScraper/Writers/CodeWriter.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Treasure.Utils;
 
-internal class CodeWriter
+internal sealed class CodeWriter
 {
     private readonly int indentSpaces = 4;
 

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,4 +1,4 @@
 [*.cs]
 
 # CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = silent
+dotnet_diagnostic.CA1707.severity = none

--- a/tests/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
+++ b/tests/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/SlnUp.Json.Tests/SlnUp.Json.Tests.csproj
+++ b/tests/SlnUp.Json.Tests/SlnUp.Json.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/SlnUp.TestLibrary/SlnUp.TestLibrary.csproj
+++ b/tests/SlnUp.TestLibrary/SlnUp.TestLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/tests/SlnUp.Tests/SlnUp.Tests.csproj
+++ b/tests/SlnUp.Tests/SlnUp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/SlnUp.Tests/SolutionFileBuilder.cs
+++ b/tests/SlnUp.Tests/SolutionFileBuilder.cs
@@ -5,7 +5,7 @@ using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text;
 
-internal class SolutionFileBuilder
+internal sealed class SolutionFileBuilder
 {
     public static readonly Version DefaultVisualStudioFullVersion = Version.Parse("16.0.28701.123");
 

--- a/tests/SlnUp.Tests/Utilities/ConsoleAssertions.cs
+++ b/tests/SlnUp.Tests/Utilities/ConsoleAssertions.cs
@@ -3,7 +3,7 @@ namespace SlnUp.Tests.Utilities;
 using FluentAssertions.Primitives;
 using System.CommandLine;
 
-internal class ConsoleAssertions : ReferenceTypeAssertions<IConsole, ConsoleAssertions>
+internal sealed class ConsoleAssertions : ReferenceTypeAssertions<IConsole, ConsoleAssertions>
 {
     protected override string Identifier => nameof(IConsole);
 


### PR DESCRIPTION
This change updates the project to use the .NET 7 SDK and addresses new analyzer warnings. The `slnup` tool now multi-targets `net6.0` and `net7.0`.