### PR TITLE
Consolidate .NET SDK installation and pin to 7.0.100

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,15 +30,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 6
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.x
-
-      - name: Setup .NET 7
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.x
+          dotnet-version: |
+            6.x
+            7.x
 
       - name: Set version
         id: version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.x
+            7.0.100
 
       - name: Set version
         id: version

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.x
+            7.0.100
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -21,15 +21,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 6
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.x
-
-      - name: Setup .NET 7
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.x
+          dotnet-version: |
+            6.x
+            7.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "7.0.100",
     "allowPrerelease": false,
-    "rollForward": "latestFeature"
+    "rollForward": "disable"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.1.3",


### PR DESCRIPTION
Consolidate .NET installations using a new syntax: https://github.com/actions/setup-dotnet#usage.
Pinning to .NET SDK 7.0.100 due to a bug executing `dotnet format` on macOS. See https://github.com/dotnet/format/issues/1785.