### PR TITLE
Allow latest SDK again and patch on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,10 @@ jobs:
             7.0.100
             7.x
 
+      - name: Patch global.json if necessary
+        shell: pwsh
+        run: ./scripts/PatchGlobalJson.ps1
+
       - name: Set version
         id: version
         shell: pwsh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,7 @@ jobs:
           dotnet-version: |
             6.x
             7.0.100
+            7.x
 
       - name: Set version
         id: version

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -27,6 +27,7 @@ jobs:
           dotnet-version: |
             6.x
             7.0.100
+            7.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -29,6 +29,10 @@ jobs:
             7.0.100
             7.x
 
+      - name: Patch global.json if necessary
+        shell: pwsh
+        run: ./scripts/PatchGlobalJson.ps1
+
       - name: Install dependencies
         run: dotnet restore
 

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "7.0.100",
     "allowPrerelease": false,
-    "rollForward": "disable"
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.1.3",

--- a/scripts/PatchGlobalJson.ps1
+++ b/scripts/PatchGlobalJson.ps1
@@ -1,0 +1,9 @@
+if (-not $IsMacOS) {
+    return
+}
+
+Write-Host 'Disabling rollForward to pin to version in global.json.'
+$globalJsonPath = Join-Path $PSScriptRoot '../global.json'
+$globalJson = Get-Content $globalJsonPath -Raw | ConvertFrom-Json
+$globalJson.sdk.rollForward = 'disable'
+$globalJson | ConvertTo-Json | Set-Content -Path $globalJsonPath


### PR DESCRIPTION
This change reverts a portion of my last change to allow us to use the latest .NET 7 SDK again. The issue is on macOS where `dotnet format` on 7.0.101 is broken, so i've included a script that patches global.json on macOS to disable the `rollForward` option. I've also installed 2 versions of the .NET 7 SDK on build agents to allow both variations to work.