### PR TITLE
Update System.IO.Abstractions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SystemIOAbstractionsVersion>19.1.5</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>19.1.14</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
  - This change updates System.IO.Abstractions to the latest since Dependabot appears to be taking a break.