### PR TITLE
Use .NET 7.0.103

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
           dotnet-version: |
             6.x
             7.0.100
-            7.x
+            7.0.103
 
       - name: Patch global.json if necessary
         shell: pwsh

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: |
             6.x
             7.0.100
-            7.x
+            7.0.103
 
       - name: Patch global.json if necessary
         shell: pwsh


### PR DESCRIPTION
As usual, `dotnet format` is broken on .NET 7.0.200 (see https://github.com/dotnet/format/issues/1800). We'll install the latest of 7.0.100 for now.