### PR TITLE
Disable rollForward hack on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.0.100
             7.0.103
 
       - name: Patch global.json if necessary

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.0.100
             7.0.103
 
       - name: Patch global.json if necessary

--- a/scripts/PatchGlobalJson.ps1
+++ b/scripts/PatchGlobalJson.ps1
@@ -1,4 +1,4 @@
-if (-not $IsMacOS) {
+if ($true) {
     return
 }
 


### PR DESCRIPTION
We previously used a PowerShell script to disable rollForward on macOS. Hoping this is no longer necessary with the updated 7.0.103 SDK.