### PR TITLE
Enable GenerateDocumentationFile for tests projects

### DIFF
--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -31,7 +31,6 @@
 
     <!-- Generate XML documentation for not test projects. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GenerateDocumentationFile Condition="$(MSBuildProjectName.EndsWith('.Tests'))">false</GenerateDocumentationFile>
 
     <!-- Normalize file paths on CI builds. -->
     <ContinuousIntegrationBuild>$(IsCIBuild)</ContinuousIntegrationBuild>

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,6 +1,11 @@
+root = false
+
 # Project specific settings
 
-[*.{cs,vb}]
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
 
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none


### PR DESCRIPTION
* The .NET 7.0 SDK 7.0.400+ added new requirements for some analyzers requiring `GenerateDocumentationFile`.
* Added new suppressions for test projects.