### PR TITLE
Fix analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ StyleCopReport.xml
 *.pgc
 *.pgd
 *.rsp
+!Directory.Build.rsp
 *.sbr
 *.tlb
 *.tli

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,2 @@
+/MaxCPUCount
+/NodeReuse:false

--- a/eng/DotNetAnalyzers.props
+++ b/eng/DotNetAnalyzers.props
@@ -6,7 +6,6 @@
     -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>7.0</AnalysisLevel>
   </PropertyGroup>

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -44,8 +44,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MSBuildTreatWarningsAsErrors>$(IsCIBuild)</MSBuildTreatWarningsAsErrors>
-    <TreatWarningsAsErrors>$(IsCIBuild)</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I'm trying a few changes to see if I can get the analyzers to behave properly locally. For some reason, they get into a state where they ignore the rules defined in the `.editorconfig` files entirely. Something similar to [this](https://github.com/dotnet/roslyn-analyzers/issues/6281), but it certainly isn't "fixed". Also, I believe there is a case where the node reuse makes this even worse requiring me to kill all `dotnet` processes in order for some settings changes to even take effect, so I'm attempting the use of the `Directory.Build.rsp` file with the `/NodeReuse:false` setting to see if it helps at all. I have a feeling that there is a quirk between the nodes that VS starts up and the ones that the CLI starts up.