### PR TITLE
Fix Dependabot xUnit.net group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   groups:
     xunit:
       patterns:
-      - "xunit.*"
+      - "xunit*"
 
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
Messed up the pattern. Fixing to include the `xunit` package.