### PR TITLE
Upgrade Treasure.Analyzers.MemberOrder to 0.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,14 +13,11 @@
   </PropertyGroup>
 
   <!--
-    Global pacakge references
+    Global package references
     https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references
     -->
   <ItemGroup>
-    <GlobalPackageReference Include="Treasure.Analyzers.MemberOrder" Version="0.2.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </GlobalPackageReference>
+    <GlobalPackageReference Include="Treasure.Analyzers.MemberOrder" Version="0.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SlnUp/SolutionFileHeader.cs
+++ b/src/SlnUp/SolutionFileHeader.cs
@@ -2,9 +2,9 @@
 
 internal record SolutionFileHeader
 {
-    public const string SupportedFileFormatVersion = "12.00";
-
     public const string DefaultMinimumVisualStudioVersion = "10.0.40219.1";
+
+    public const string SupportedFileFormatVersion = "12.00";
 
     /// <summary>
     /// Gets or sets the file format version.


### PR DESCRIPTION
This change upgrades Treasure.Analyzers.MemberOrder to 0.3.0 supporting all types.