### PR TITLE
Use ternary instead of switch

### DIFF
--- a/src/SlnUp/SolutionFile.cs
+++ b/src/SlnUp/SolutionFile.cs
@@ -117,11 +117,9 @@ internal class SolutionFile
         string fileFormatVersionLine = $"Microsoft Visual Studio Solution File, Format Version {fileHeader.FileFormatVersion}";
         lines[this.fileFormatLineNumber] = fileFormatVersionLine;
 
-        string lastVisualStudioMajorVersionLine = fileHeader.LastVisualStudioMajorVersion switch
-        {
-            >= 16 => $"# Visual Studio Version {fileHeader.LastVisualStudioMajorVersion}",
-            _ => $"# Visual Studio {fileHeader.LastVisualStudioMajorVersion}",
-        };
+        string lastVisualStudioMajorVersionLine = fileHeader.LastVisualStudioMajorVersion >= 16
+            ? $"# Visual Studio Version {fileHeader.LastVisualStudioMajorVersion}"
+            : $"# Visual Studio {fileHeader.LastVisualStudioMajorVersion}";
 
         lines[this.fileFormatLineNumber + 1] = lastVisualStudioMajorVersionLine;
 


### PR DESCRIPTION
While addressing analyzer warnings for .NET 8, I removed a switch case leaving 2 cases. Codacy, a new tool i'm testing, identified that as a good candidate for a ternary instead of a switch statement, which is completely correct.