### PR TITLE
Add TestableIO.System.IO.Abstractions.Analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     -->
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.282" />
+    <GlobalPackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0" />
     <GlobalPackageReference Include="Treasure.Analyzers.MemberOrder" Version="0.3.2" />
   </ItemGroup>
 

--- a/src/VisualStudio.VersionScraper/VisualStudioVersionDocScraper.cs
+++ b/src/VisualStudio.VersionScraper/VisualStudioVersionDocScraper.cs
@@ -189,7 +189,9 @@ internal sealed class VisualStudioVersionDocScraper
 
     private HtmlDocument LoadVisualStudioVersionDocument(string url, string cacheFolderName)
     {
+#pragma warning disable IO0006 // Replace Path class with IFileSystem.Path for improved testability
         string cachePath = Path.Join(Path.GetTempPath(), cacheFolderName);
+#pragma warning restore IO0006 // Replace Path class with IFileSystem.Path for improved testability
         HtmlWeb web = new()
         {
             CachePath = cachePath,


### PR DESCRIPTION
Use `TestableIO.System.IO.Abstractions.Analyzers` to make sure we use `System.IO.Abstractions` as much as possible.