### PR TITLE
Upgrade packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SystemIOAbstractionsVersion>19.2.69</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>19.2.87</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
   <!--

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="System.CommandLine.NamingConventionBinder"         Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions"                            Version="$(SystemIOAbstractionsVersion)" />
     <PackageVersion Include="System.Text.Json"                                  Version="8.0.0" />
-    <PackageVersion Include="Treasure.Utils.Argument"                           Version="1.0.44" />
+    <PackageVersion Include="Treasure.Utils.Argument"                           Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="FluentAssertions"                                  Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.8.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="xunit"                                             Version="2.6.1" />
-    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.3" />
+    <PackageVersion Include="xunit"                                             Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change upgrades packages to the latest since Dependabot is broken on .NET 8.