### PR TITLE
Update packages and fix new analyzer warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,11 +33,11 @@
 
   <ItemGroup>
     <PackageVersion Include="Humanizer.Core"                                    Version="2.14.1" />
-    <PackageVersion Include="HtmlAgilityPack"                                   Version="1.11.58" />
+    <PackageVersion Include="HtmlAgilityPack"                                   Version="1.11.59" />
     <PackageVersion Include="System.CommandLine"                                Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder"         Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions"                            Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="System.Text.Json"                                  Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json"                                  Version="8.0.2" />
     <PackageVersion Include="Treasure.Utils.Argument"                           Version="1.1.0" />
   </ItemGroup>
 

--- a/tests/SlnUp.Core.Tests/VersionManagerTests.cs
+++ b/tests/SlnUp.Core.Tests/VersionManagerTests.cs
@@ -31,10 +31,10 @@ public class VersionManagerTests
     public void Construct_Versions()
     {
         // Arrange
-        IReadOnlyList<VisualStudioVersion> versions = new[]
-        {
+        IReadOnlyList<VisualStudioVersion> versions =
+        [
             new VisualStudioVersion(VisualStudioProduct.VisualStudio2022, Version.Parse("17.2.5"), Version.Parse("17.2.32616.157"), "Release", false),
-        };
+        ];
 
         // Act
         VersionManager versionManager = new(versions);

--- a/tests/SlnUp.Core.Tests/VisualStudioVersionTests.cs
+++ b/tests/SlnUp.Core.Tests/VisualStudioVersionTests.cs
@@ -2,8 +2,8 @@
 
 public class VisualStudioVersionTests
 {
-    private static readonly IReadOnlyList<VisualStudioVersion> commonVersions = new[]
-    {
+    private static readonly IReadOnlyList<VisualStudioVersion> commonVersions =
+    [
         new VisualStudioVersion(
             VisualStudioProduct.VisualStudio2019,
             Version.Parse("16.11.6"),
@@ -14,7 +14,7 @@ public class VisualStudioVersionTests
             Version.Parse("17.0.0"),
             Version.Parse("17.0.31903.59"),
             "Release")
-    };
+    ];
 
     [Fact]
     public void Constructor()

--- a/tests/SlnUp.Json.Tests/VisualStudioVersionJsonHelperTests.cs
+++ b/tests/SlnUp.Json.Tests/VisualStudioVersionJsonHelperTests.cs
@@ -26,8 +26,8 @@ public class VisualStudioVersionJsonHelperTests
   }
 ]";
 
-    private static readonly IReadOnlyList<VisualStudioVersion> commonVersions = new[]
-    {
+    private static readonly IReadOnlyList<VisualStudioVersion> commonVersions =
+    [
         new VisualStudioVersion(
             VisualStudioProduct.VisualStudio2019,
             Version.Parse("16.11.6"),
@@ -37,8 +37,8 @@ public class VisualStudioVersionJsonHelperTests
             VisualStudioProduct.VisualStudio2022,
             Version.Parse("17.0.0"),
             Version.Parse("17.0.31903.59"),
-            "Release")
-    };
+            "Release"),
+    ];
 
     [Fact]
     public void FromJson()
@@ -108,7 +108,7 @@ public class VisualStudioVersionJsonHelperTests
         const string expectedJson = "[]";
 
         // Act
-        string json = VisualStudioVersionJsonHelper.ToJson(Enumerable.Empty<VisualStudioVersion>());
+        string json = VisualStudioVersionJsonHelper.ToJson([]);
 
         // Assert
         json.Should().Be(expectedJson);


### PR DESCRIPTION
- Updated the System.Text.Json and HtmlAgilityPack packages to their latest versions.
- Addressed new analyzer warnings that come with the latest version of the .NET 8 SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies for enhanced stability and performance.
- **Tests**
	- Refactored test code for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->