### PR TITLE
Update NuGet packages to the latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SystemIOAbstractionsVersion>20.0.28</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>21.0.2</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
   <!--
@@ -17,7 +17,7 @@
     https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references
     -->
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.302" />
+    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.315" />
     <GlobalPackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0" />
     <GlobalPackageReference Include="Treasure.Analyzers.MemberOrder" Version="0.3.2" />
   </ItemGroup>
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Humanizer.Core"                                    Version="2.14.1" />
-    <PackageVersion Include="HtmlAgilityPack"                                   Version="1.11.59" />
+    <PackageVersion Include="HtmlAgilityPack"                                   Version="1.11.60" />
     <PackageVersion Include="System.CommandLine"                                Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder"         Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions"                            Version="$(SystemIOAbstractionsVersion)" />
@@ -48,8 +48,8 @@
     <PackageVersion Include="FluentAssertions"                                  Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.9.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="xunit"                                             Version="2.7.0" />
-    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.7" />
+    <PackageVersion Include="xunit"                                             Version="2.7.1" />
+    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change updates all packages to their latest versions while Dependabot continues to fail.