### PR TITLE
chore: Update Divergic.Logging.Xunit to Neovolve.Logging.Xunit version 6.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector"                                Version="6.0.2" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.2" />
-    <PackageVersion Include="Divergic.Logging.Xunit"                            Version="4.2.0" />
+    <PackageVersion Include="Neovolve.Logging.Xunit"                            Version="6.1.0" />
     <PackageVersion Include="FluentAssertions"                                  Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.10.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />


### PR DESCRIPTION
The `Divergic.Logging.Xunit` package has been deprecated in favor of the new name `Neovolve.Logging.Xunit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the logging framework for testing, which may improve compatibility and performance.
  
- **Chores**
	- Replaced the outdated logging package to ensure up-to-date dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->