### PR TITLE
Simplify argument validation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,6 @@
     <PackageVersion Include="System.CommandLine.NamingConventionBinder"         Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions"                            Version="$(SystemIOAbstractionsVersion)" />
     <PackageVersion Include="System.Text.Json"                                  Version="9.0.0" />
-    <PackageVersion Include="Treasure.Utils.Argument"                           Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">

--- a/src/SlnUp.Core/Extensions/VersionExtensions.cs
+++ b/src/SlnUp.Core/Extensions/VersionExtensions.cs
@@ -2,8 +2,6 @@
 
 using System;
 
-using Treasure.Utils;
-
 /// <summary>
 /// Class VersionExtensions.
 /// </summary>
@@ -16,7 +14,12 @@ public static class VersionExtensions
     /// <param name="other">The other.</param>
     /// <returns><c>true</c> if the major and minor versions are the same; otherwise, <c>false</c>.</returns>
     public static bool HasSameMajorMinor(this Version version, Version other)
-        => Argument.NotNull(version).Major == Argument.NotNull(other).Major && version.Minor == other.Minor;
+    {
+        ArgumentNullException.ThrowIfNull(version);
+        ArgumentNullException.ThrowIfNull(other);
+
+        return version.Major == other.Major && version.Minor == other.Minor;
+    }
 
     /// <summary>
     /// Determines if the version declares a 2-part version number.
@@ -25,7 +28,7 @@ public static class VersionExtensions
     /// <returns><c>true</c> if the version declares a 2-part version number, <c>false</c> otherwise.</returns>
     public static bool Is2PartVersion(this Version version)
     {
-        Argument.NotNull(version);
+        ArgumentNullException.ThrowIfNull(version);
         return version is { Major: >= 0, Minor: >= 0, Build: -1, Revision: -1 };
     }
 
@@ -36,7 +39,7 @@ public static class VersionExtensions
     /// <returns><c>true</c> if the version declares a 3-part version number, <c>false</c> otherwise.</returns>
     public static bool Is3PartVersion(this Version version)
     {
-        Argument.NotNull(version);
+        ArgumentNullException.ThrowIfNull(version);
         return version is { Major: >= 0, Minor: >= 0, Build: >= 0, Revision: -1 };
     }
 
@@ -47,7 +50,7 @@ public static class VersionExtensions
     /// <returns><c>true</c> if the version declares a 4-part version number, <c>false</c> otherwise.</returns>
     public static bool Is4PartVersion(this Version version)
     {
-        Argument.NotNull(version);
+        ArgumentNullException.ThrowIfNull(version);
         return version is { Major: >= 0, Minor: >= 0, Build: >= 0, Revision: >= 0 };
     }
 }

--- a/src/SlnUp.Core/SlnUp.Core.csproj
+++ b/src/SlnUp.Core/SlnUp.Core.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" />
     <PackageReference Include="System.IO.Abstractions" />
-    <PackageReference Include="Treasure.Utils.Argument" />
   </ItemGroup>
 
 </Project>

--- a/src/SlnUp.Json/SlnUp.Json.csproj
+++ b/src/SlnUp.Json/SlnUp.Json.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="Treasure.Utils.Argument" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlnUp.Json/VisualStudioVersionJsonHelper.cs
+++ b/src/SlnUp.Json/VisualStudioVersionJsonHelper.cs
@@ -6,8 +6,6 @@ using System.Text.Json.Serialization;
 
 using SlnUp.Core;
 
-using Treasure.Utils;
-
 /// <summary>
 /// A helper when converting <see cref="VisualStudioVersion" /> data to and from json.
 /// </summary>
@@ -40,7 +38,11 @@ public static class VisualStudioVersionJsonHelper
     /// <param name="filePath">The file path.</param>
     /// <returns><see cref="IReadOnlyList{VisualStudioVersion}" />.</returns>
     public static IReadOnlyList<VisualStudioVersion> FromJsonFile(IFileSystem fileSystem, string filePath)
-        => FromJson(Argument.NotNull(fileSystem).File.ReadAllText(filePath));
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        return FromJson(fileSystem.File.ReadAllText(filePath));
+    }
 
     /// <summary>
     /// Serializes to json content.
@@ -56,5 +58,9 @@ public static class VisualStudioVersionJsonHelper
     /// <param name="versions">The versions.</param>
     /// <param name="filePath">The file path.</param>
     public static void ToJsonFile(IFileSystem fileSystem, IEnumerable<VisualStudioVersion> versions, string filePath)
-        => Argument.NotNull(fileSystem).File.WriteAllText(filePath, ToJson(versions));
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        fileSystem.File.WriteAllText(filePath, ToJson(versions));
+    }
 }

--- a/src/VisualStudio.VersionScraper/Writers/CSharp/CSharpVersionWriter.cs
+++ b/src/VisualStudio.VersionScraper/Writers/CSharp/CSharpVersionWriter.cs
@@ -4,8 +4,6 @@ using System.IO.Abstractions;
 
 using SlnUp.Core;
 
-using Treasure.Utils;
-
 internal sealed class CSharpVersionWriter
 {
     private const string ClassName = "VersionManager";
@@ -16,7 +14,12 @@ internal sealed class CSharpVersionWriter
 
     private readonly IFileSystem fileSystem;
 
-    public CSharpVersionWriter(IFileSystem fileSystem) => this.fileSystem = Argument.NotNull(fileSystem);
+    public CSharpVersionWriter(IFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        this.fileSystem = fileSystem;
+    }
 
     public void WriteClassToFile(IEnumerable<VisualStudioVersion> versions, string filePath)
     {

--- a/src/VisualStudio.VersionScraper/Writers/CodeWriter.cs
+++ b/src/VisualStudio.VersionScraper/Writers/CodeWriter.cs
@@ -5,8 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 
 using SlnUp.Core;
 
-using Treasure.Utils;
-
 internal sealed class CodeWriter
 {
     private readonly int indentSpaces = 4;
@@ -20,7 +18,11 @@ internal sealed class CodeWriter
     /// </summary>
     /// <param name="writer">The writer.</param>
     public CodeWriter(StreamWriter writer)
-        => this.writer = Argument.NotNull(writer);
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        this.writer = writer;
+    }
 
     /// <summary>
     /// Indents the code.

--- a/tests/SlnUp.TestLibrary/ScopedDirectory.cs
+++ b/tests/SlnUp.TestLibrary/ScopedDirectory.cs
@@ -4,8 +4,6 @@ using System.IO.Abstractions;
 
 using SlnUp.Core;
 
-using Treasure.Utils;
-
 /// <summary>
 /// Class ScopedDirectory.
 /// Implements the <see cref="IDisposable" />
@@ -43,8 +41,11 @@ public class ScopedDirectory : IDisposable
     /// <param name="path">The directory path.</param>
     public ScopedDirectory(IFileSystem fileSystem, string path)
     {
-        this.FileSystem = Argument.NotNull(fileSystem);
-        this.Path = Argument.NotNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        this.FileSystem = fileSystem;
+        this.Path = path;
 
         if (!fileSystem.Directory.Exists(path))
         {

--- a/tests/SlnUp.TestLibrary/ScopedFile.cs
+++ b/tests/SlnUp.TestLibrary/ScopedFile.cs
@@ -4,8 +4,6 @@ using System.IO.Abstractions;
 
 using SlnUp.Core;
 
-using Treasure.Utils;
-
 /// <summary>
 /// Class ScopedFile.
 /// Implements the <see cref="IDisposable" />
@@ -43,8 +41,11 @@ public class ScopedFile : IDisposable
     /// <param name="filePath">The file path.</param>
     public ScopedFile(IFileSystem fileSystem, string filePath)
     {
-        this.FileSystem = Argument.NotNull(fileSystem);
-        this.Path = Argument.NotNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        this.FileSystem = fileSystem;
+        this.Path = filePath;
 
         if (!fileSystem.File.Exists(filePath))
         {

--- a/tests/SlnUp.TestLibrary/TemporaryDirectory.cs
+++ b/tests/SlnUp.TestLibrary/TemporaryDirectory.cs
@@ -2,8 +2,6 @@
 
 using System.IO.Abstractions;
 
-using Treasure.Utils;
-
 /// <summary>
 /// Class TemporaryDirectory.
 /// </summary>
@@ -25,7 +23,7 @@ public static class TemporaryDirectory
     /// <returns><see cref="ScopedDirectory"/>.</returns>
     public static ScopedDirectory Create(IFileSystem fileSystem, string directoryName)
     {
-        Argument.NotNull(fileSystem);
+        ArgumentNullException.ThrowIfNull(fileSystem);
 
         string directoryPath = GetPathWithName(fileSystem, directoryName);
 
@@ -68,7 +66,7 @@ public static class TemporaryDirectory
     public static string GetPathWithName(IFileSystem fileSystem, string directoryName)
     {
         ArgumentNullException.ThrowIfNull(fileSystem);
-        Argument.NotNullOrWhiteSpace(directoryName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryName);
 
         return fileSystem.Path.Combine(GetPath(fileSystem), directoryName);
     }


### PR DESCRIPTION
Now that we only support .NET 8+, I can remove the dependency on Treasure.Utils.Argument.