### PR TITLE
Enable Dependabot to update the .NET SDK

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -3,12 +3,16 @@ name: Install tools
 runs:
   using: "composite"
   steps:
-    - name: Setup .NET
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Setup additional .NET SDK versions
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
             8.x
-            9.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
       - "Nerdbank.GitVersioning"
       - "nbgv"
 
+- package-ecosystem: 'dotnet-sdk'
+  directory: "/"
+  schedule:
+    interval: 'weekly'
+    day: 'tuesday'
+    time: '20:00'
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
This change enables Dependabot to update the .NET SDK per [new release](https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/).