### PR TITLE
Update xUnit to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,8 +46,9 @@
     <PackageVersion Include="FluentAssertions"                                  Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.12.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="xunit"                                             Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.8.2" />
+    <PackageVersion Include="xunit.analyzers"                                   Version="1.18.0" />
+    <PackageVersion Include="xunit.v3"                                          Version="1.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio"                         Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
+++ b/tests/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,7 +29,8 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/SlnUp.Json.Tests/SlnUp.Json.Tests.csproj
+++ b/tests/SlnUp.Json.Tests/SlnUp.Json.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,7 +29,8 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/SlnUp.Tests/SlnUp.Tests.csproj
+++ b/tests/SlnUp.Tests/SlnUp.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,7 +23,8 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This change updates xUnit to v3 by following the [migration guide](https://xunit.net/docs/getting-started/v3/migration).