### PR TITLE
Use Windows 2025 for builds

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          { os: windows, buildAgent: windows-latest },
+          { os: windows, buildAgent: windows-2025 },
           { os: ubuntu, buildAgent: ubuntu-latest },
           { os: macos, buildAgent: macos-14 }
         ]


### PR DESCRIPTION
According to [this announcement](https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/), Windows Server 2025 is now available to use in preview.. Initial build shows it being much faster than previous Windows build agents, so we'll try it out.