### PR TITLE
Update dependabot config: remove reviewers/assignees, add coverlet group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
     time: '17:00'
     timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
-  reviewers:
-    - craigktreasure
-  assignees:
-    - craigktreasure
   groups:
     xunit:
       patterns:
@@ -20,6 +16,9 @@ updates:
       patterns:
       - "Nerdbank.GitVersioning"
       - "nbgv"
+    coverlet:
+      patterns:
+      - "coverlet*"
 
 - package-ecosystem: 'dotnet-sdk'
   directory: "/"
@@ -27,6 +26,7 @@ updates:
     interval: 'weekly'
     day: 'tuesday'
     time: '22:00'
+    timezone: 'America/Los_Angeles'
 
 - package-ecosystem: github-actions
   directory: "/"
@@ -36,7 +36,3 @@ updates:
     time: '17:00'
     timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
-  reviewers:
-    - craigktreasure
-  assignees:
-    - craigktreasure


### PR DESCRIPTION
- Remove hardcoded reviewers and assignees from nuget and github-actions
- Add coverlet dependency group for nuget ecosystem
- Add timezone setting for dotnet-sdk ecosystem