### PR TITLE
Use ReferenceTrimmer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     -->
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.334" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.11" />
     <GlobalPackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0" />
     <GlobalPackageReference Include="Treasure.Analyzers.MemberOrder" Version="0.3.2" />
   </ItemGroup>

--- a/src/SlnUp.Core/SlnUp.Core.csproj
+++ b/src/SlnUp.Core/SlnUp.Core.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" />
-    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/SlnUp.Json/SlnUp.Json.csproj
+++ b/src/SlnUp.Json/SlnUp.Json.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
+++ b/tests/SlnUp.Core.Tests/SlnUp.Core.Tests.csproj
@@ -38,7 +38,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\SlnUp.Core\SlnUp.Core.csproj" />
     <ProjectReference Include="..\..\src\SlnUp.Json\SlnUp.Json.csproj" />
-    <ProjectReference Include="..\SlnUp.TestLibrary\SlnUp.TestLibrary.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change enables the use of https://github.com/dfederm/ReferenceTrimmer to identify unused package or project references.

I've fixed up the unnecessary package and project references.