### PR TITLE
chore(deps): Bump NuGet package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.12.3" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions" Version="$(SystemIOAbstractionsVersion)" />
@@ -43,11 +43,11 @@
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="$(SystemIOAbstractionsVersion)" />
     <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-    <PackageVersion Include="xunit.v3" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates several NuGet packages to their latest versions. This ensures the project benefits from the latest bug fixes, performance improvements, and features.

The following packages were updated:
- `HtmlAgilityPack` from `1.12.3` to `1.12.4`
- `Microsoft.NET.Test.Sdk` from `17.14.1` to `18.0.0`
- `xunit.runner.visualstudio` from `3.1.4` to `3.1.5`
- `xunit.v3` from `3.0.1` to `3.1.0`