### PR TITLE
Reduce GitHub Actions artifact storage usage

### DIFF
--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -76,16 +76,10 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-      - name: Upload output artifact
-        if: ${{ inputs.uploadArtifacts }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: output_${{ inputs.artifactSuffix }}
-          path: __artifacts/bin
-
       - name: Upload package artifact
         if: ${{ inputs.uploadArtifacts }}
         uses: actions/upload-artifact@v7
         with:
           name: packages_${{ inputs.artifactSuffix }}
           path: __artifacts/package
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Remove the `output_*` artifact upload step from the build workflow — these ~160 MB build binary artifacts were not consumed by any downstream workflow (Release only uses `packages_*`)
- Add explicit `retention-days: 14` to the remaining package artifact upload
- Also deleted 112 stale artifacts via API, reducing active storage from ~11.3 GB to ~63 MB