### PR TITLE
Upgrade dependencies and group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,9 @@ updates:
     timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
   groups:
-    xunit:
+    all-nuget:
       patterns:
-      - "xunit*"
-    gitversioning:
-      patterns:
-      - "Nerdbank.GitVersioning"
-      - "nbgv"
-    coverlet:
-      patterns:
-      - "coverlet*"
+      - "*"
 
 - package-ecosystem: 'dotnet-sdk'
   directory: "/"
@@ -36,3 +29,7 @@ updates:
     time: '17:00'
     timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
+  groups:
+    all-actions:
+      patterns:
+      - "*"

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Find CI run to release
         id: find_run
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = '${{ inputs.run_id }}';
@@ -61,7 +61,7 @@ jobs:
 
       - name: Validate CI run
         id: get_version
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = '${{ steps.find_run.outputs.run_id }}';

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     -->
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.334" />
-    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.4.5" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.4.7" />
     <GlobalPackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0" />
     <GlobalPackageReference Include="Treasure.Analyzers.MemberOrder" Version="0.3.96" />
   </ItemGroup>
@@ -39,10 +39,10 @@
   </ItemGroup>
 
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage"         Version="18.5.2" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage"         Version="18.6.2" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                Version="2.2.1" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="TUnit"                                             Version="1.24.31" />
+    <PackageVersion Include="TUnit"                                             Version="1.32.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Upgrade NuGet packages: `Microsoft.Testing.Extensions.CodeCoverage` 18.5.2 → 18.6.2, `Microsoft.Testing.Platform.MSBuild` 2.1.0 → 2.2.1, `ReferenceTrimmer` 3.4.5 → 3.4.7, `TUnit` 1.24.31 → 1.32.0
- Upgrade `actions/github-script` from v8 to v9 in Release workflow
- Configure Dependabot to group all NuGet packages and all GitHub Actions into single PRs per ecosystem