### PR TITLE
Upgrade dependencies and add Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+﻿{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)",
+      "Bash(dotnet sdk check *)",
+      "Bash(dotnet list package *)",
+      "PowerShell(dotnet build:*)",
+      "PowerShell(dotnet test:*)",
+      "PowerShell(dotnet sdk check *)",
+      "PowerShell(dotnet list package *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __*
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # Created by https://www.toptal.com/developers/gitignore/api/macos,windows,visualstudio,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,windows,visualstudio,visualstudiocode
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,13 +28,13 @@
     https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references
     -->
   <ItemGroup Label="Source Only Global Packages" Condition=" '$(SourceOnlyPackagesEnabled)' == 'true' ">
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
     <PackageVersion Include="System.IO.Abstractions" Version="$(SystemIOAbstractionsVersion)" />
   </ItemGroup>
 
@@ -42,7 +42,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage"         Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                Version="2.2.1" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="TUnit"                                             Version="1.32.0" />
+    <PackageVersion Include="TUnit"                                             Version="1.35.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Upgrade NuGet packages: `Microsoft.SourceLink.GitHub` 10.0.201 → 10.0.202, `System.CommandLine` 2.0.5 → 2.0.6, `TUnit` 1.32.0 → 1.35.2.
- Add `.claude/settings.json` with a baseline permissions allowlist for common `dotnet` commands.
- Ignore `.claude/settings.local.json` so local-only overrides stay out of the repo.