### PR TITLE
Replace Codecov with ReportGenerator coverage gate

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "nbgv"
       ]
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.11",
+      "commands": [
+        "reportgenerator"
+      ]
     }
   }
 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
     name: Build SlnUp
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     uses: ./.github/workflows/workflow_build.yml
-    secrets: inherit
     with:
       # don't check format on CI builds due to common breaking changes in the .NET SDK
       checkFormat: false

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,7 +15,6 @@ jobs:
           { os: macos, buildAgent: macos-14 }
         ]
     uses: ./.github/workflows/workflow_build.yml
-    secrets: inherit
     with:
       artifactSuffix: ${{ matrix.platform.os }}
       buildAgent: ${{ matrix.platform.buildAgent }}

--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -61,20 +61,29 @@ jobs:
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal --coverage --coverage-output-format cobertura
 
-      - name: Install dotnet-coverage tool
-        run: dotnet tool install --global dotnet-coverage
+      - name: Generate coverage report and enforce thresholds
+        run: >
+          dotnet tool run reportgenerator
+          "-reports:__artifacts/test-results/**/*.cobertura.xml"
+          "-targetdir:__artifacts/coverage-report"
+          "-reporttypes:MarkdownSummaryGithub;Html"
+          "-classfilters:-System.Text.RegularExpressions.Generated*"
+          "minimumCoverageThresholds:lineCoverage=95"
+          "minimumCoverageThresholds:branchCoverage=95"
 
-      - name: Merge coverage reports
-        run: dotnet-coverage merge __artifacts/test-results/**/*.cobertura.xml -f cobertura -o __artifacts/test-results/codecov/coverage.cobertura.xml
+      - name: Publish coverage summary
+        # Publish even when the threshold check above fails the build.
+        if: ${{ !cancelled() && hashFiles('__artifacts/coverage-report/SummaryGithub.md') != '' }}
+        shell: pwsh
+        run: Get-Content __artifacts/coverage-report/SummaryGithub.md | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+      - name: Upload coverage report
+        if: ${{ !cancelled() && hashFiles('__artifacts/coverage-report/SummaryGithub.md') != '' }}
+        uses: actions/upload-artifact@v7
         with:
-          name: codecov
-          directory: __artifacts/test-results/codecov
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          verbose: true
+          name: coverage-report_${{ inputs.artifactSuffix }}
+          path: __artifacts/coverage-report
+          retention-days: 14
 
       - name: Upload package artifact
         if: ${{ inputs.uploadArtifacts }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ that allows you to easily change the Visual Studio version information in a
 solution file using a Visual Studio version number.
 
 ![CI Build](https://github.com/craigktreasure/SlnUp/workflows/SlnUp-CI/badge.svg?branch=main)
-[![codecov](https://codecov.io/gh/craigktreasure/SlnUp/branch/main/graph/badge.svg?token=SV8DFLV2H4)](https://codecov.io/gh/craigktreasure/SlnUp)
 [![NuGet](https://img.shields.io/nuget/v/SlnUp)](https://www.nuget.org/packages/SlnUp/)
 [![NuGet](https://img.shields.io/nuget/dt/SlnUp)](https://www.nuget.org/packages/SlnUp/)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 95%
-        threshold: 1%


### PR DESCRIPTION
## Summary

Codecov was sold to Harness. This replaces the upload with a fully in-repo approach using the [ReportGenerator](https://github.com/danielpalme/ReportGenerator) dotnet tool — no third-party GitHub Actions involved:

- **Coverage summary** rendered into the workflow job summary (`MarkdownSummaryGithub` report type)
- **HTML report** uploaded as a build artifact for line-by-line drill-down, named per matrix leg
- **Coverage gate**: `minimumCoverageThresholds` fails the build when line or branch coverage falls below the floor
- Tool is version-pinned in `.config/dotnet-tools.json`, restored by the existing `install-tools` action, and already covered by Dependabot's nuget updates
- The `dotnet-coverage` global install and merge steps are gone — ReportGenerator reads all nine cobertura files directly
- Removes `codecov.yml` and the README badge
- Drops `secrets: inherit` from `CI.yml` and `PR.yml`, since `CODECOV_TOKEN` was the only secret the build workflow used

## Thresholds

Both line and branch coverage are gated at **95%**, matching the target the old `codecov.yml` used. Current coverage is 100% line and 98.8% branch.

Source-generated regex code is excluded via `-classfilters`. It appears three times (once per TFM) and accounts for the entire gap between the raw 89.9% line coverage and the 100% of hand-written code. Codecov never counted it either — those files live under `__artifacts/obj` and do not exist in the commit, which is what made a 95% target viable there.

## Notes

- Multiple thresholds must be passed as separate arguments. Combining them as `lineCoverage=95;branchCoverage=95` throws a config-binder exception and still exits 0.
- On a breach, ReportGenerator writes the reports before exiting non-zero, so the `!cancelled()` guards on the summary and artifact steps still publish.
- The summary step uses `pwsh` rather than `cat >> "$GITHUB_STEP_SUMMARY"` so it works on the windows-2025 leg of the PR matrix.
- `.config/**` is in `CI.yml`'s `paths-ignore`, so Dependabot bumps of the tool will not trigger a CI build on main. They still run the full PR matrix, so the gate is exercised.
